### PR TITLE
Add Google-style rating stars to testimonials

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -335,6 +335,13 @@ section#especializacion .grid-2 > a {
     vertical-align: middle;
 }
 
+.rating .icon {
+    width: 1.1em;
+    height: 1.1em;
+    vertical-align: middle;
+    line-height: 1;
+}
+
 /* ICONOS */
 .info-card .icon-wrapper,
 .content-card .icon-wrapper {

--- a/icons/star-empty.svg
+++ b/icons/star-empty.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+  <path fill="#DADCE0" d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
+</svg>

--- a/icons/star-half.svg
+++ b/icons/star-half.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+  <defs>
+    <linearGradient id="half-fill" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="50%" stop-color="#F4B400"/>
+      <stop offset="50%" stop-color="#DADCE0"/>
+      <stop offset="100%" stop-color="#DADCE0"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#half-fill)" d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
+</svg>

--- a/icons/star-rating.svg
+++ b/icons/star-rating.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+  <path fill="#F4B400" d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -362,42 +362,42 @@
                     <div class="testimonial-slider">
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>Gran profesional me ha ayudado a saber gestionarme y guiarme. Muy recomendable un 10.</blockquote>
                                 <cite>C.M.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>Un profesional excelente. Estoy muy agradecida con Javi por su profesionalidad y empatía. Desde el primer momento me hizo sentir cómoda y comprendida, creando un espacio seguro donde trabajar en mi bienestar.</blockquote>
                                 <cite>Dra. M.L.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>Estoy muy contenta. Totalmente recomendable. Es profesional pero también muy cercano. Me ha ayudado a encontrar y desarrollar métodos adecuados a mi personalidad para tratar mi problema.</blockquote>
                                 <cite>C.G.M.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>Javi me ha ayudado a salir de un período bastante complicado. Estoy muy contento con el proceso y el acompañamiento. El trato es cercano, amable y sincero.</blockquote>
                                 <cite>P.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>...me ha sabido escuchar y comprender en todo momento; me ha facilitado herramientas y estrategias para abordar las dificultades diarias que surgen a menudo...</blockquote>
                                 <cite>E.F.M.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>...escucha activamente, da herramientas y actividades para avanzar... Su servicio es de gran utilidad y personalmente creo que me ha ayudado a mejorar mi calidad de vida.</blockquote>
                                 <cite>M.</cite>
                             </div>

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -282,42 +282,42 @@
                     <div class="testimonial-slider">
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>Gran profesional me ha ayudado a saber gestionarme y guiarme. Muy recomendable un 10.</blockquote>
                                 <cite>C.M.</cite>
                             </div>
                         </div>
                          <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>Un profesional excelente. Estoy muy agradecida con Javi por su profesionalidad y empatía. Desde el primer momento me hizo sentir cómoda y comprendida, creando un espacio seguro donde trabajar en mi bienestar.</blockquote>
                                 <cite>Dra. M.L.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>Estoy muy contenta. Totalmente recomendable. Es profesional pero también muy cercano. Me ha ayudado a encontrar y desarrollar métodos adecuados a mi personalidad para tratar mi problema.</blockquote>
                                 <cite>C.G.M.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>Javi me ha ayudado a salir de un período bastante complicado. Estoy muy contento con el proceso y el acompañamiento. El trato es cercano, amable y sincero.</blockquote>
                                 <cite>P.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>...me ha sabido escuchar y comprender en todo momento; me ha facilitado herramientas y estrategias para abordar las dificultades diarias que surgen a menudo...</blockquote>
                                 <cite>E.F.M.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>...escucha activamente, da herramientas y actividades para avanzar... Su servicio es de gran utilidad y personalmente creo que me ha ayudado a mejorar mi calidad de vida.</blockquote>
                                 <cite>M.</cite>
                             </div>

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -252,42 +252,42 @@
                     <div class="testimonial-slider">
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>Gran profesional me ha ayudado a saber gestionarme y guiarme. Muy recomendable un 10.</blockquote>
                                 <cite>C.M.</cite>
                             </div>
                         </div>
                          <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>Un profesional excelente. Estoy muy agradecida con Javi por su profesionalidad y empatía. Desde el primer momento me hizo sentir cómoda y comprendida, creando un espacio seguro donde trabajar en mi bienestar.</blockquote>
                                 <cite>Dra. M.L.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>Estoy muy contenta. Totalmente recomendable. Es profesional pero también muy cercano. Me ha ayudado a encontrar y desarrollar métodos adecuados a mi personalidad para tratar mi problema.</blockquote>
                                 <cite>C.G.M.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>Javi me ha ayudado a salir de un período bastante complicado. Estoy muy contento con el proceso y el acompañamiento. El trato es cercano, amable y sincero.</blockquote>
                                 <cite>P.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>...me ha sabido escuchar y comprender en todo momento; me ha facilitado herramientas y estrategias para abordar las dificultades diarias que surgen a menudo...</blockquote>
                                 <cite>E.F.M.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars"><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""><img src="icons/star.svg" class="icon" alt=""></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
                                 <blockquote>...escucha activamente, da herramientas y actividades para avanzar... Su servicio es de gran utilidad y personalmente creo que me ha ayudado a mejorar mi calidad de vida.</blockquote>
                                 <cite>M.</cite>
                             </div>


### PR DESCRIPTION
## Summary
- add reusable star-rating, star-empty, and star-half SVG icons styled with the Google yellow palette
- update testimonial sections across key pages to use the new rating icons and semantic alt text
- add targeted CSS to normalize rating icon sizing without forcing color overrides

## Testing
- No automated tests were run (not applicable)
- Visual check: Verified testimonial stars display in yellow on index.html

------
https://chatgpt.com/codex/tasks/task_e_68e19bfab4e88325a2789d196d1fe253