### PR TITLE
Iconos locales – fase 2 (heredar color)

### DIFF
--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -72,7 +72,9 @@
                 <li><a href="terapia-online.html">Terapia Online</a></li>
             </ul>
             <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
-                <img src="icons/bars.svg" class="icon" alt="">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M16 96a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32A16 16 0 0 1 16 96Zm0 160a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32a16 16 0 0 1-16-16Zm16 144a16 16 0 0 0 0 32h384a16 16 0 0 0 0-32H32Z" fill="currentColor" />
+</svg>
             </button>
         </nav>
     </header>
@@ -179,9 +181,9 @@
             <div class="footer-col">
                 <h4>Contacto</h4>
                 <ul>
-                    <li><img src="icons/map-marker-alt.svg" class="icon" style="margin-right: 0.5rem;" alt="">Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
-                    <li><a href="tel:+34621372442"><img src="icons/phone.svg" class="icon" style="margin-right: 0.5rem;" alt="Teléfono">621 372 442</a></li>
-                    <li><a href="mailto:javicaceres@cop.es"><img src="icons/envelope.svg" class="icon" style="margin-right: 0.5rem;" alt="Correo">javicaceres@cop.es</a></li>
+                    <li><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z" fill="currentColor" /></svg></span>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
+                    <li><a href="tel:+34621372442"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Teléfono" focusable="false"><path d="M224.2 89C216.3 70.1 195.7 60.1 176.1 65.4L170.6 66.9C106 84.5 50.8 147.1 66.9 223.3C104 398.3 241.7 536 416.7 573.1C493 589.3 555.5 534 573.1 469.4L574.6 463.9C580 444.2 569.9 423.6 551.1 415.8L453.8 375.3C437.3 368.4 418.2 373.2 406.8 387.1L368.2 434.3C297.9 399.4 241.3 341 208.8 269.3L253 233.3C266.9 222 271.6 202.9 264.8 186.3L224.2 89z" fill="currentColor" /></svg></span>621 372 442</a></li>
+                    <li><a href="mailto:javicaceres@cop.es"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Correo" focusable="false"><path d="M112 128C85.5 128 64 149.5 64 176C64 191.1 71.1 205.3 83.2 214.4L291.2 370.4C308.3 383.2 331.7 383.2 348.8 370.4L556.8 214.4C568.9 205.3 576 191.1 576 176C576 149.5 554.5 128 528 128L112 128zM64 260L64 448C64 483.3 92.7 512 128 512L512 512C547.3 512 576 483.3 576 448L576 260L377.6 408.8C343.5 434.4 296.5 434.4 262.4 408.8L64 260z" fill="currentColor" /></svg></span>javicaceres@cop.es</a></li>
                 </ul>
             </div>
             <div class="footer-col">

--- a/codigo-deontologico.html
+++ b/codigo-deontologico.html
@@ -73,7 +73,9 @@
                 <li><a href="terapia-online.html">Terapia Online</a></li>
             </ul>
             <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
-                <img src="icons/bars.svg" class="icon" alt="">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M16 96a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32A16 16 0 0 1 16 96Zm0 160a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32a16 16 0 0 1-16-16Zm16 144a16 16 0 0 0 0 32h384a16 16 0 0 0 0-32H32Z" fill="currentColor" />
+</svg>
             </button>
         </nav>
     </header>
@@ -99,7 +101,7 @@
             <p style="margin-top: 2rem;">Para una consulta detallada del documento completo, puede acceder al código deontológico vigente directamente:</p>
             <p style="text-align: center; margin: 2rem 0;">
                 <a href="https://arxiu.copc.cat/adjuntos/adjunto_188.1524062657.pdf" target="_blank" rel="noopener noreferrer" style="font-size: 1.1rem;">
-                    <img src="icons/file-pdf.svg" class="icon" style="margin-right: 0.5rem;" alt="">
+                    <span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M128 64C92.7 64 64 92.7 64 128L64 512C64 547.3 92.7 576 128 576L208 576L208 464C208 428.7 236.7 400 272 400L448 400L448 234.5C448 217.5 441.3 201.2 429.3 189.2L322.7 82.7C310.7 70.7 294.5 64 277.5 64L128 64zM389.5 240L296 240C282.7 240 272 229.3 272 216L272 122.5L389.5 240zM272 444C261 444 252 453 252 464L252 592C252 603 261 612 272 612C283 612 292 603 292 592L292 564L304 564C337.1 564 364 537.1 364 504C364 470.9 337.1 444 304 444L272 444zM304 524L292 524L292 484L304 484C315 484 324 493 324 504C324 515 315 524 304 524zM400 444C389 444 380 453 380 464L380 592C380 603 389 612 400 612L432 612C460.7 612 484 588.7 484 560L484 496C484 467.3 460.7 444 432 444L400 444zM420 572L420 484L432 484C438.6 484 444 489.4 444 496L444 560C444 566.6 438.6 572 432 572L420 572zM508 464L508 592C508 603 517 612 528 612C539 612 548 603 548 592L548 548L576 548C587 548 596 539 596 528C596 517 587 508 576 508L548 508L548 484L576 484C587 484 596 475 596 464C596 453 587 444 576 444L528 444C517 444 508 453 508 464z" fill="currentColor" /></svg></span>
                     <strong>Consultar el Código Deontológico del COPC (PDF)</strong>
                 </a>
             </p>
@@ -167,9 +169,9 @@
             <div class="footer-col">
                 <h4>Contacto</h4>
                 <ul>
-                    <li><img src="icons/map-marker-alt.svg" class="icon" style="margin-right: 0.5rem;" alt="">Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
-                    <li><a href="tel:+34621372442"><img src="icons/phone.svg" class="icon" style="margin-right: 0.5rem;" alt="Teléfono">621 372 442</a></li>
-                    <li><a href="mailto:javicaceres@cop.es"><img src="icons/envelope.svg" class="icon" style="margin-right: 0.5rem;" alt="Correo">javicaceres@cop.es</a></li>
+                    <li><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z" fill="currentColor" /></svg></span>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
+                    <li><a href="tel:+34621372442"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Teléfono" focusable="false"><path d="M224.2 89C216.3 70.1 195.7 60.1 176.1 65.4L170.6 66.9C106 84.5 50.8 147.1 66.9 223.3C104 398.3 241.7 536 416.7 573.1C493 589.3 555.5 534 573.1 469.4L574.6 463.9C580 444.2 569.9 423.6 551.1 415.8L453.8 375.3C437.3 368.4 418.2 373.2 406.8 387.1L368.2 434.3C297.9 399.4 241.3 341 208.8 269.3L253 233.3C266.9 222 271.6 202.9 264.8 186.3L224.2 89z" fill="currentColor" /></svg></span>621 372 442</a></li>
+                    <li><a href="mailto:javicaceres@cop.es"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Correo" focusable="false"><path d="M112 128C85.5 128 64 149.5 64 176C64 191.1 71.1 205.3 83.2 214.4L291.2 370.4C308.3 383.2 331.7 383.2 348.8 370.4L556.8 214.4C568.9 205.3 576 191.1 576 176C576 149.5 554.5 128 528 128L112 128zM64 260L64 448C64 483.3 92.7 512 128 512L512 512C547.3 512 576 483.3 576 448L576 260L377.6 408.8C343.5 434.4 296.5 434.4 262.4 408.8L64 260z" fill="currentColor" /></svg></span>javicaceres@cop.es</a></li>
                 </ul>
             </div>
             <div class="footer-col">

--- a/css/legal-styles.css
+++ b/css/legal-styles.css
@@ -4,10 +4,20 @@
     vertical-align: middle;
 }
 
+.text-primary {
+    color: var(--primary);
+}
+
+.text-earth {
+    color: var(--earth);
+}
+
 /* ESTILOS PARA PÁGINAS LEGALES */
 :root {
     --accent-empathy: #D97757;
     --accent-wisdom: #6B7A99;
+    --primary: var(--accent-wisdom);
+    --earth: var(--accent-empathy);
     --text-strongest: #2D3748;
     --text-strong: #4A5568;
     --text-medium: #6C7A90;

--- a/css/styles.css
+++ b/css/styles.css
@@ -2,6 +2,8 @@
 :root {
     --accent-empathy: #D97757;
     --accent-wisdom: #6B7A99;
+    --primary: var(--accent-wisdom);
+    --earth: var(--accent-empathy);
     --text-strongest: #2D3748;
     --text-strong: #4A5568;
     --text-medium: #6C7A90;
@@ -335,6 +337,14 @@ section#especializacion .grid-2 > a {
     vertical-align: middle;
 }
 
+.text-primary {
+    color: var(--primary);
+}
+
+.text-earth {
+    color: var(--earth);
+}
+
 .rating .icon {
     width: 1.1em;
     height: 1.1em;
@@ -346,13 +356,13 @@ section#especializacion .grid-2 > a {
 .info-card .icon-wrapper,
 .content-card .icon-wrapper {
     font-size: 2rem;
-    color: var(--accent-wisdom);
+    color: var(--primary);
     margin-bottom: 1.5rem;
     opacity: 0.9;
 }
 
 .specialization-card .icon-wrapper {
-    color: var(--accent-empathy);
+    color: var(--earth);
 }
 
 .btn-primary .icon {
@@ -456,7 +466,7 @@ section#especializacion .grid-2 > a {
 }
 
 .tarifa-card li .icon {
-    color: var(--accent-empathy);
+    color: var(--earth);
     margin-right: 0.5rem;
 }
 
@@ -514,7 +524,7 @@ section#especializacion .grid-2 > a {
     transform: translateY(-50%);
     background-color: var(--white);
     border: 1px solid var(--bg-subtle);
-    color: var(--accent-wisdom);
+    color: var(--primary);
     width: 50px;
     height: 50px;
     border-radius: 50%;
@@ -634,7 +644,7 @@ section#especializacion .grid-2 > a {
 
 .faq-question .icon {
     transition: transform 0.3s ease, color 0.3s ease;
-    color: var(--accent-wisdom);
+    color: var(--primary);
 }
 
 .faq-answer {
@@ -651,7 +661,7 @@ section#especializacion .grid-2 > a {
 
 .faq-item.active .faq-question .icon {
     transform: rotate(180deg);
-    color: var(--accent-empathy);
+    color: var(--earth);
 }
 
 .faq-item.active .faq-answer {

--- a/index.html
+++ b/index.html
@@ -177,7 +177,9 @@
                 <li><a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información." target="_blank" class="btn btn-primary">Pedir Cita</a></li>
             </ul>
             <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
-                <img src="icons/bars.svg" class="icon" alt="">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M16 96a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32A16 16 0 0 1 16 96Zm0 160a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32a16 16 0 0 1-16-16Zm16 144a16 16 0 0 0 0 32h384a16 16 0 0 0 0-32H32Z" fill="currentColor" />
+</svg>
             </button>
         </nav>
     </header>
@@ -218,17 +220,17 @@
                 </div>
                 <div class="grid-3">
                     <div class="info-card">
-                        <div class="icon-wrapper"><img src="icons/comments.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false"><path d="M416 208C416 305.2 330 384 224 384C197.3 384 171.9 379 148.8 370L67.2 413.2C57.9 418.1 46.5 416.4 39 409C31.5 401.6 29.8 390.1 34.8 380.8L70.4 313.6C46.3 284.2 32 247.6 32 208C32 110.8 118 32 224 32C330 32 416 110.8 416 208zM416 576C321.9 576 243.6 513.9 227.2 432C347.2 430.5 451.5 345.1 463 229.3C546.3 248.5 608 317.6 608 400C608 439.6 593.7 476.2 569.6 505.6L605.2 572.8C610.1 582.1 608.4 593.5 601 601C593.6 608.5 582.1 610.2 572.8 605.2L491.2 562C468.1 571 442.7 576 416 576z" fill="currentColor" /></svg></div>
                         <h3>Comunicación Asertiva</h3>
                         <p>Expresa tus necesidades y pon límites de forma clara y respetuosa, mejorando tus vínculos.</p>
                     </div>
                     <div class="info-card">
-                        <div class="icon-wrapper"><img src="icons/brain.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false"><path d="M184 120C184 89.1 209.1 64 240 64L264 64C281.7 64 296 78.3 296 96L296 544C296 561.7 281.7 576 264 576L232 576C202.2 576 177.1 555.6 170 528C169.3 528 168.7 528 168 528C123.8 528 88 492.2 88 448C88 430 94 413.4 104 400C84.6 385.4 72 362.2 72 336C72 305.1 89.6 278.2 115.2 264.9C108.1 252.9 104 238.9 104 224C104 179.8 139.8 144 184 144L184 120zM456 120L456 144C500.2 144 536 179.8 536 224C536 239 531.9 253 524.8 264.9C550.5 278.2 568 305 568 336C568 362.2 555.4 385.4 536 400C546 413.4 552 430 552 448C552 492.2 516.2 528 472 528C471.3 528 470.7 528 470 528C462.9 555.6 437.8 576 408 576L376 576C358.3 576 344 561.7 344 544L344 96C344 78.3 358.3 64 376 64L400 64C430.9 64 456 89.1 456 120z" fill="currentColor" /></svg></div>
                         <h3>Calma Mental</h3>
                         <p>Aprende a gestionar el "runrún" de la ansiedad y a dirigir tu atención hacia lo que de verdad importa.</p>
                     </div>
                     <div class="info-card">
-                        <div class="icon-wrapper"><img src="icons/heart.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false"><path d="M305 151.1L320 171.8L335 151.1C360 116.5 400.2 96 442.9 96C516.4 96 576 155.6 576 229.1L576 231.7C576 343.9 436.1 474.2 363.1 529.9C350.7 539.3 335.5 544 320 544C304.5 544 289.2 539.4 276.9 529.9C203.9 474.2 64 343.9 64 231.7L64 229.1C64 155.6 123.6 96 197.1 96C239.8 96 280 116.5 305 151.1z" fill="currentColor" /></svg></div>
                         <h3>Relaciones Sanas</h3>
                         <p>Construye conexiones más auténticas y seguras con tu pareja, familia y amigos.</p>
                     </div>
@@ -245,17 +247,17 @@
                 </div>
                 <div class="grid-3">
                     <div class="info-card">
-                        <div class="icon-wrapper"><img src="icons/handshake-angle.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" class="icon" aria-hidden="true" focusable="false"><path d="M543.9 251.4c0-1.1 .1-2.2 .1-3.4c0-48.6-39.4-88-88-88l-40 0H320l-16 0 0 0v16 72c0 22.1-17.9 40-40 40s-40-17.9-40-40V128h.4c4-36 34.5-64 71.6-64H408c2.8 0 5.6 .2 8.3 .5l40.1-40.1c21.9-21.9 57.3-21.9 79.2 0l78.1 78.1c21.9 21.9 21.9 57.3 0 79.2l-69.7 69.7zM192 128V248c0 39.8 32.2 72 72 72s72-32.2 72-72V192h80l40 0c30.9 0 56 25.1 56 56c0 27.2-19.4 49.9-45.2 55c8.2 8.6 13.2 20.2 13.2 33c0 26.5-21.5 48-48 48h-2.7c1.8 5 2.7 10.4 2.7 16c0 26.5-21.5 48-48 48H224c-.9 0-1.8 0-2.7-.1l-37.7 37.7c-21.9 21.9-57.3 21.9-79.2 0L26.3 407.6c-21.9-21.9-21.9-57.3 0-79.2L96 258.7V224c0-53 43-96 96-96z" fill="currentColor" /></svg></div>
                         <h3>Terapia Colaborativa</h3>
                         <p>Tú eres el experto/a en tu vida. Mi trabajo no es darte consejos, sino crear un diálogo donde tus propias fortalezas y soluciones salgan a la luz.</p>
                     </div>
                     <div class="info-card">
-                        <div class="icon-wrapper"><img src="icons/rocket.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false"><path d="M192 384L88.5 384C63.6 384 48.3 356.9 61.1 335.5L114 247.3C122.7 232.8 138.3 224 155.2 224L250.2 224C326.3 95.1 439.8 88.6 515.7 99.7C528.5 101.6 538.5 111.6 540.3 124.3C551.4 200.2 544.9 313.7 416 389.8L416 484.8C416 501.7 407.2 517.3 392.7 526L304.5 578.9C283.2 591.7 256 576.3 256 551.5L256 448C256 412.7 227.3 384 192 384L191.9 384zM464 224C464 197.5 442.5 176 416 176C389.5 176 368 197.5 368 224C368 250.5 389.5 272 416 272C442.5 272 464 250.5 464 224z" fill="currentColor" /></svg></div>
                         <h3>Enfoque Breve y Eficaz</h3>
                         <p>Nos centramos en el cambio desde el minuto cero. El objetivo es que notes mejoras y adquieras herramientas prácticas en pocas sesiones (la media es de 6-8).</p>
                     </div>
                     <div class="info-card">
-                        <div class="icon-wrapper"><img src="icons/lightbulb.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false"><path d="M420.9 448C428.2 425.7 442.8 405.5 459.3 388.1C492 353.7 512 307.2 512 256C512 150 426 64 320 64C214 64 128 150 128 256C128 307.2 148 353.7 180.7 388.1C197.2 405.5 211.9 425.7 219.1 448L420.8 448zM416 496L224 496L224 512C224 556.2 259.8 592 304 592L336 592C380.2 592 416 556.2 416 512L416 496zM312 176C272.2 176 240 208.2 240 248C240 261.3 229.3 272 216 272C202.7 272 192 261.3 192 248C192 181.7 245.7 128 312 128C325.3 128 336 138.7 336 152C336 165.3 325.3 176 312 176z" fill="currentColor" /></svg></div>
                         <h3>Centrada en Recursos</h3>
                         <p>No existe la "resistencia". Creo firmemente que tienes todos los recursos que necesitas. Juntos, los descubriremos y los pondremos a trabajar para ti.</p>
                     </div>
@@ -319,9 +321,15 @@
                         <div class="price">55€</div>
                         <p class="duration">55 minutos</p>
                         <ul>
-                            <li><img src="icons/check.svg" class="icon" alt=""> Comodidad desde tu hogar.</li>
-                            <li><img src="icons/check.svg" class="icon" alt=""> Misma eficacia que la presencial.</li>
-                            <li><img src="icons/check.svg" class="icon" alt=""> Flexibilidad horaria total.</li>
+                            <li><span class="text-earth"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
+</svg></span> Comodidad desde tu hogar.</li>
+                            <li><span class="text-earth"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
+</svg></span> Misma eficacia que la presencial.</li>
+                            <li><span class="text-earth"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
+</svg></span> Flexibilidad horaria total.</li>
                         </ul>
                         <a href="terapia-online.html" class="btn btn-secondary">Saber Más</a>
                     </div>
@@ -330,9 +338,15 @@
                         <div class="price">65€</div>
                         <p class="duration">55 minutos | En mi consulta de Roses</p>
                         <ul>
-                            <li><img src="icons/check.svg" class="icon" alt=""> El valor del encuentro cara a cara.</li>
-                            <li><img src="icons/check.svg" class="icon" alt=""> Un espacio 100% seguro y confidencial.</li>
-                            <li><img src="icons/check.svg" class="icon" alt=""> Atención cercana y personalizada.</li>
+                            <li><span class="text-earth"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
+</svg></span> El valor del encuentro cara a cara.</li>
+                            <li><span class="text-earth"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
+</svg></span> Un espacio 100% seguro y confidencial.</li>
+                            <li><span class="text-earth"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
+</svg></span> Atención cercana y personalizada.</li>
                         </ul>
                         <a href="https://wa.me/34621372442?text=Hola%20Javi,%20quiero%20pedir%20cita%20para%20una%20sesión%20presencial." target="_blank" class="btn btn-primary">Pedir Cita Presencial</a>
                     </div>
@@ -341,9 +355,15 @@
                         <div class="price">70€</div>
                         <p class="duration">Hasta 90 minutos</p>
                         <ul>
-                            <li><img src="icons/check.svg" class="icon" alt=""> Espacio neutral para ambos.</li>
-                            <li><img src="icons/check.svg" class="icon" alt=""> Método Gottman y TSB.</li>
-                            <li><img src="icons/check.svg" class="icon" alt=""> Presencial en Roses y Online.</li>
+                            <li><span class="text-earth"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
+</svg></span> Espacio neutral para ambos.</li>
+                            <li><span class="text-earth"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
+</svg></span> Método Gottman y TSB.</li>
+                            <li><span class="text-earth"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
+</svg></span> Presencial en Roses y Online.</li>
                         </ul>
                         <a href="terapia-pareja.html" class="btn btn-secondary">Saber Más</a>
                     </div>
@@ -403,8 +423,12 @@
                             </div>
                         </div>
                     </div>
-                    <button class="slider-btn prev-btn" aria-label="Reseña anterior"><img src="icons/chevron-left.svg" class="icon" alt=""></button>
-                    <button class="slider-btn next-btn" aria-label="Siguiente reseña"><img src="icons/chevron-right.svg" class="icon" alt=""></button>
+                    <button class="slider-btn prev-btn" aria-label="Reseña anterior"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M224 32a24 24 0 0 1 0 34L82.5 208 224 346a24 24 0 1 1-34 34l-160-160a24 24 0 0 1 0-34l160-160A24 24 0 0 1 224 32Z" fill="currentColor" />
+</svg></button>
+                    <button class="slider-btn next-btn" aria-label="Siguiente reseña"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0l160 160a24 24 0 0 1 0 34l-160 160a24 24 0 0 1-34-34L173.5 208 32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></button>
                 </div>
                 
                 <div class="slider-pagination" id="slider-pagination"></div>
@@ -461,27 +485,39 @@
                 </div>
                 <div class="faq-list" style="max-width: 800px; margin: 0 auto;">
                     <div class="faq-item">
-                        <div class="faq-question"><span>¿Cómo sé si realmente necesito ir al psicólogo?</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Cómo sé si realmente necesito ir al psicólogo?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>Si sientes que un problema (ansiedad, tristeza, estrés) interfiere en tu vida diaria, te impide disfrutar o te sientes atascado, la terapia puede ser de gran ayuda. No hace falta "tocar fondo". A veces, una simple conversación puede clarificar si es el momento adecuado para ti.</p></div>
                     </div>
                     <div class="faq-item">
-                        <div class="faq-question"><span>¿Qué pasará en la primera sesión? Da un poco de miedo...</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Qué pasará en la primera sesión? Da un poco de miedo...</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>Es normal sentir nervios. La primera sesión es simplemente una conversación para conocernos. Me explicarás qué te trae a consulta, y yo te explicaré cómo trabajo. El objetivo es que te sientas cómodo/a y seguro/a, sin juicios. Desde este primer encuentro ya empezaremos a buscar pequeñas excepciones al problema.</p></div>
                     </div>
                     <div class="faq-item">
-                        <div class="faq-question"><span>¿Cuánto tiempo dura la terapia? No quiero estar años...</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Cuánto tiempo dura la terapia? No quiero estar años...</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>Mi enfoque es la Terapia Breve. La media de sesiones se sitúa entre 6 y 8. A veces son 4, otras pueden ser 15. El objetivo no es que dependas de la terapia, sino que adquieras las herramientas para ser tu propio/a terapeuta lo antes posible.</p></div>
                     </div>
                      <div class="faq-item">
-                        <div class="faq-question"><span>¿Todo lo que cuente es confidencial?</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Todo lo que cuente es confidencial?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>Absolutamente. La confidencialidad es la base de la terapia y está protegida por el código deontológico. Todo lo que hablemos en sesión es estrictamente privado, salvo en situaciones de riesgo grave para ti o para terceros, tal y como marca la ley.</p></div>
                     </div>
                      <div class="faq-item">
-                        <div class="faq-question"><span>¿Con qué frecuencia son las sesiones?</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Con qué frecuencia son las sesiones?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>Para empezar y coger impulso, lo ideal suele ser una frecuencia semanal o quincenal. A medida que vayas notando mejoría y aplicando los cambios, iremos espaciando las sesiones para fomentar tu autonomía, que es el objetivo final.</p></div>
                     </div>
                      <div class="faq-item">
-                        <div class="faq-question"><span>¿Cómo se realiza el pago de las sesiones presenciales?</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Cómo se realiza el pago de las sesiones presenciales?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>El pago se puede realizar cómodamente al finalizar la sesión en la consulta, ya sea en efectivo o a través de Bizum, como prefieras.</p></div>
                     </div>
                 </div>
@@ -524,13 +560,13 @@
                 <h4>Contacto</h4>
                 <ul>
                     <li>
-                        <img src="icons/map-marker-alt.svg" class="icon" style="margin-right: 0.5rem;" alt="">
+                        <span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z" fill="currentColor" /></svg></span>
                         <a href="https://maps.app.goo.gl/qK8TCrotW8m6P8oCA" target="_blank" rel="noopener">
                             Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses
                         </a>
                     </li>
-                    <li><a href="tel:+34621372442"><img src="icons/phone.svg" class="icon" style="margin-right: 0.5rem;" alt="Teléfono">621 372 442</a></li>
-                    <li><a href="mailto:javicaceres@cop.es"><img src="icons/envelope.svg" class="icon" style="margin-right: 0.5rem;" alt="Correo">javicaceres@cop.es</a></li>
+                    <li><a href="tel:+34621372442"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Teléfono" focusable="false"><path d="M224.2 89C216.3 70.1 195.7 60.1 176.1 65.4L170.6 66.9C106 84.5 50.8 147.1 66.9 223.3C104 398.3 241.7 536 416.7 573.1C493 589.3 555.5 534 573.1 469.4L574.6 463.9C580 444.2 569.9 423.6 551.1 415.8L453.8 375.3C437.3 368.4 418.2 373.2 406.8 387.1L368.2 434.3C297.9 399.4 241.3 341 208.8 269.3L253 233.3C266.9 222 271.6 202.9 264.8 186.3L224.2 89z" fill="currentColor" /></svg></span>621 372 442</a></li>
+                    <li><a href="mailto:javicaceres@cop.es"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Correo" focusable="false"><path d="M112 128C85.5 128 64 149.5 64 176C64 191.1 71.1 205.3 83.2 214.4L291.2 370.4C308.3 383.2 331.7 383.2 348.8 370.4L556.8 214.4C568.9 205.3 576 191.1 576 176C576 149.5 554.5 128 528 128L112 128zM64 260L64 448C64 483.3 92.7 512 128 512L512 512C547.3 512 576 483.3 576 448L576 260L377.6 408.8C343.5 434.4 296.5 434.4 262.4 408.8L64 260z" fill="currentColor" /></svg></span>javicaceres@cop.es</a></li>
                 </ul>
             </div>
             <div class="footer-col">

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -73,7 +73,9 @@
                 <li><a href="terapia-online.html">Terapia Online</a></li>
             </ul>
             <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
-                <img src="icons/bars.svg" class="icon" alt="">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M16 96a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32A16 16 0 0 1 16 96Zm0 160a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32a16 16 0 0 1-16-16Zm16 144a16 16 0 0 0 0 32h384a16 16 0 0 0 0-32H32Z" fill="currentColor" />
+</svg>
             </button>
         </nav>
     </header>
@@ -159,9 +161,9 @@
             <div class="footer-col">
                 <h4>Contacto</h4>
                 <ul>
-                    <li><img src="icons/map-marker-alt.svg" class="icon" style="margin-right: 0.5rem;" alt="">Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
-                    <li><a href="tel:+34621372442"><img src="icons/phone.svg" class="icon" style="margin-right: 0.5rem;" alt="Teléfono">621 372 442</a></li>
-                    <li><a href="mailto:javicaceres@cop.es"><img src="icons/envelope.svg" class="icon" style="margin-right: 0.5rem;" alt="Correo">javicaceres@cop.es</a></li>
+                    <li><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z" fill="currentColor" /></svg></span>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
+                    <li><a href="tel:+34621372442"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Teléfono" focusable="false"><path d="M224.2 89C216.3 70.1 195.7 60.1 176.1 65.4L170.6 66.9C106 84.5 50.8 147.1 66.9 223.3C104 398.3 241.7 536 416.7 573.1C493 589.3 555.5 534 573.1 469.4L574.6 463.9C580 444.2 569.9 423.6 551.1 415.8L453.8 375.3C437.3 368.4 418.2 373.2 406.8 387.1L368.2 434.3C297.9 399.4 241.3 341 208.8 269.3L253 233.3C266.9 222 271.6 202.9 264.8 186.3L224.2 89z" fill="currentColor" /></svg></span>621 372 442</a></li>
+                    <li><a href="mailto:javicaceres@cop.es"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Correo" focusable="false"><path d="M112 128C85.5 128 64 149.5 64 176C64 191.1 71.1 205.3 83.2 214.4L291.2 370.4C308.3 383.2 331.7 383.2 348.8 370.4L556.8 214.4C568.9 205.3 576 191.1 576 176C576 149.5 554.5 128 528 128L112 128zM64 260L64 448C64 483.3 92.7 512 128 512L512 512C547.3 512 576 483.3 576 448L576 260L377.6 408.8C343.5 434.4 296.5 434.4 262.4 408.8L64 260z" fill="currentColor" /></svg></span>javicaceres@cop.es</a></li>
                 </ul>
             </div>
             <div class="footer-col">

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -73,7 +73,9 @@
                 <li><a href="terapia-online.html">Terapia Online</a></li>
             </ul>
             <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
-                <img src="icons/bars.svg" class="icon" alt="">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M16 96a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32A16 16 0 0 1 16 96Zm0 160a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32a16 16 0 0 1-16-16Zm16 144a16 16 0 0 0 0 32h384a16 16 0 0 0 0-32H32Z" fill="currentColor" />
+</svg>
             </button>
         </nav>
     </header>
@@ -161,9 +163,9 @@
             <div class="footer-col">
                 <h4>Contacto</h4>
                 <ul>
-                    <li><img src="icons/map-marker-alt.svg" class="icon" style="margin-right: 0.5rem;" alt="">Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
-                    <li><a href="tel:+34621372442"><img src="icons/phone.svg" class="icon" style="margin-right: 0.5rem;" alt="Teléfono">621 372 442</a></li>
-                    <li><a href="mailto:javicaceres@cop.es"><img src="icons/envelope.svg" class="icon" style="margin-right: 0.5rem;" alt="Correo">javicaceres@cop.es</a></li>
+                    <li><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z" fill="currentColor" /></svg></span>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
+                    <li><a href="tel:+34621372442"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Teléfono" focusable="false"><path d="M224.2 89C216.3 70.1 195.7 60.1 176.1 65.4L170.6 66.9C106 84.5 50.8 147.1 66.9 223.3C104 398.3 241.7 536 416.7 573.1C493 589.3 555.5 534 573.1 469.4L574.6 463.9C580 444.2 569.9 423.6 551.1 415.8L453.8 375.3C437.3 368.4 418.2 373.2 406.8 387.1L368.2 434.3C297.9 399.4 241.3 341 208.8 269.3L253 233.3C266.9 222 271.6 202.9 264.8 186.3L224.2 89z" fill="currentColor" /></svg></span>621 372 442</a></li>
+                    <li><a href="mailto:javicaceres@cop.es"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Correo" focusable="false"><path d="M112 128C85.5 128 64 149.5 64 176C64 191.1 71.1 205.3 83.2 214.4L291.2 370.4C308.3 383.2 331.7 383.2 348.8 370.4L556.8 214.4C568.9 205.3 576 191.1 576 176C576 149.5 554.5 128 528 128L112 128zM64 260L64 448C64 483.3 92.7 512 128 512L512 512C547.3 512 576 483.3 576 448L576 260L377.6 408.8C343.5 434.4 296.5 434.4 262.4 408.8L64 260z" fill="currentColor" /></svg></span>javicaceres@cop.es</a></li>
                 </ul>
             </div>
             <div class="footer-col">

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -144,7 +144,9 @@
                 <li><a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" class="btn btn-primary">Pedir Cita</a></li>
             </ul>
             <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
-                <img src="icons/bars.svg" class="icon" alt="">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M16 96a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32A16 16 0 0 1 16 96Zm0 160a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32a16 16 0 0 1-16-16Zm16 144a16 16 0 0 0 0 32h384a16 16 0 0 0 0-32H32Z" fill="currentColor" />
+</svg>
             </button>
         </nav>
     </header>
@@ -183,17 +185,17 @@
                 </div>
                 <div class="grid-3">
                     <div class="info-card">
-                        <div class="icon-wrapper"><img src="icons/bullseye.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false"><path d="M512 320C512 214 426 128 320 128C214 128 128 214 128 320C128 426 214 512 320 512C426 512 512 426 512 320zM64 320C64 178.6 178.6 64 320 64C461.4 64 576 178.6 576 320C576 461.4 461.4 576 320 576C178.6 576 64 461.4 64 320zM320 400C364.2 400 400 364.2 400 320C400 275.8 364.2 240 320 240C275.8 240 240 275.8 240 320C240 364.2 275.8 400 320 400zM320 176C399.5 176 464 240.5 464 320C464 399.5 399.5 464 320 464C240.5 464 176 399.5 176 320C176 240.5 240.5 176 320 176zM288 320C288 302.3 302.3 288 320 288C337.7 288 352 302.3 352 320C352 337.7 337.7 352 320 352C302.3 352 288 337.7 288 320z" fill="currentColor" /></svg></div>
                         <h3>Enfocada en Soluciones</h3>
                         <p>No nos perdemos en el pasado. Buscamos activamente lo que ya funciona en tu vida y lo amplificamos. El cambio se construye sobre tus fortalezas.</p>
                     </div>
                     <div class="info-card">
-                        <div class="icon-wrapper"><img src="icons/forward.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false"><path d="M403.7 107.1C392.1 96 375 92.9 360.3 99.2C345.6 105.5 336 120 336 136L336 272.3L163.7 107.2C152.1 96 135 92.9 120.3 99.2C105.6 105.5 96 120 96 136L96 504C96 520 105.6 534.5 120.3 540.8C135 547.1 152.1 544 163.7 532.9L336 367.7L336 504C336 520 345.6 534.5 360.3 540.8C375 547.1 392.1 544 403.7 532.9L595.7 348.9C603.6 341.4 608 330.9 608 320C608 309.1 603.5 298.7 595.7 291.1L403.7 107.1z" fill="currentColor" /></svg></div>
                         <h3>Máxima Eficiencia</h3>
                         <p>Al ser un modelo tan focalizado, a menudo se requieren menos sesiones. Cada minuto de la sesión online se aprovecha para construir el cambio.</p>
                     </div>
                     <div class="info-card">
-                        <div class="icon-wrapper"><img src="icons/user-friends.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" class="icon" aria-hidden="true" focusable="false"><path d="M192 256c61.9 0 112-50.1 112-112S253.9 32 192 32 80 82.1 80 144s50.1 112 112 112zm76.8 32h-8.3c-20.8 10-43.9 16-68.5 16s-47.6-6-68.5-16h-8.3C51.6 288 0 339.6 0 403.2V432c0 26.5 21.5 48 48 48h288c26.5 0 48-21.5 48-48v-28.8c0-63.6-51.6-115.2-115.2-115.2zM480 256c53 0 96-43 96-96s-43-96-96-96-96 43-96 96 43 96 96 96zm48 32h-3.8c-13.9 4.8-28.6 8-44.2 8s-30.3-3.2-44.2-8H432c-20.4 0-39.2 5.9-55.7 15.4 24.4 26.3 39.7 61.2 39.7 99.8v38.4c0 2.2-.5 4.3-.6 6.4H592c26.5 0 48-21.5 48-48 0-61.9-50.1-112-112-112z" fill="currentColor" /></svg></div>
                         <h3>Tú eres el/la experto/a</h3>
                         <p>Mi rol no es darte respuestas, sino hacer las preguntas adecuadas para que tú encuentres las tuyas. Es un trabajo en equipo, 100% colaborativo.</p>
                     </div>
@@ -226,17 +228,17 @@
                 </div>
                 <div class="grid-3">
                     <div class="content-card">
-                        <div class="icon-wrapper"><img src="icons/comment-dots.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="icon" aria-hidden="true" focusable="false"><path d="M256 32C114.6 32 0 125.1 0 240c0 49.6 21.4 95 57 130.7C44.5 421.1 2.7 466 2.2 466.5c-2.2 2.3-2.8 5.7-1.5 8.7S4.8 480 8 480c66.3 0 116-31.8 140.6-51.4 32.7 12.3 69 19.4 107.4 19.4 141.4 0 256-93.1 256-208S397.4 32 256 32zM128 272c-17.7 0-32-14.3-32-32s14.3-32 32-32 32 14.3 32 32-14.3 32-32 32zm128 0c-17.7 0-32-14.3-32-32s14.3-32 32-32 32 14.3 32 32-14.3 32-32 32zm128 0c-17.7 0-32-14.3-32-32s14.3-32 32-32 32 14.3 32 32-14.3 32-32 32z" fill="currentColor" /></svg></div>
                         <h3>1. Contacto Inicial</h3>
                         <p>Me escribes por WhatsApp o email. Te explico cómo trabajo y resolvemos tus dudas iniciales.</p>
                     </div>
                     <div class="content-card">
-                        <div class="icon-wrapper"><img src="icons/calendar-check.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false"><path d="M416 64C433.7 64 448 78.3 448 96L448 128L480 128C515.3 128 544 156.7 544 192L544 480C544 515.3 515.3 544 480 544L160 544C124.7 544 96 515.3 96 480L96 192C96 156.7 124.7 128 160 128L192 128L192 96C192 78.3 206.3 64 224 64C241.7 64 256 78.3 256 96L256 128L384 128L384 96C384 78.3 398.3 64 416 64zM438 225.7C427.3 217.9 412.3 220.3 404.5 231L285.1 395.2L233 343.1C223.6 333.7 208.4 333.7 199.1 343.1C189.8 352.5 189.7 367.7 199.1 377L271.1 449C276.1 454 283 456.5 289.9 456C296.8 455.5 303.3 451.9 307.4 446.2L443.3 259.2C451.1 248.5 448.7 233.5 438 225.7z" fill="currentColor" /></svg></div>
                         <h3>2. Primera Sesión</h3>
                         <p>Acordamos día y hora. Te envío el enlace de la videollamada (Google Meet). Nos conocemos y definimos los objetivos.</p>
                     </div>
                     <div class="content-card">
-                        <div class="icon-wrapper"><img src="icons/route.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="icon" aria-hidden="true" focusable="false"><path d="M416 320h-96c-17.6 0-32-14.4-32-32s14.4-32 32-32h96s96-107 96-160-43-96-96-96-96 43-96 96c0 25.5 22.2 63.4 45.3 96H320c-52.9 0-96 43.1-96 96s43.1 96 96 96h96c17.6 0 32 14.4 32 32s-14.4 32-32 32H185.5c-16 24.8-33.8 47.7-47.3 64H416c52.9 0 96-43.1 96-96s-43.1-96-96-96zm0-256c17.7 0 32 14.3 32 32s-14.3 32-32 32-32-14.3-32-32 14.3-32 32-32zM96 256c-53 0-96 43-96 96s96 160 96 160 96-107 96-160-43-96-96-96zm0 128c-17.7 0-32-14.3-32-32s14.3-32 32-32 32 14.3 32 32-14.3 32-32 32z" fill="currentColor" /></svg></div>
                         <h3>3. Tu Proceso</h3>
                         <p>Trabajamos juntos, sesión a sesión, con herramientas prácticas y cambios reales. Tú marcas el ritmo.</p>
                     </div>
@@ -253,17 +255,17 @@
                 </div>
                 <div class="grid-3">
                     <div class="info-card">
-                        <div class="icon-wrapper"><img src="icons/home.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon" aria-hidden="true" focusable="false"><path d="M280.37 148.26L96 300.11V464a16 16 0 0 0 16 16l112.06-.29a16 16 0 0 0 15.92-16V368a16 16 0 0 1 16-16h64a16 16 0 0 1 16 16v95.64a16 16 0 0 0 16 16.05L464 480a16 16 0 0 0 16-16V300L295.67 148.26a12.19 12.19 0 0 0-15.3 0zM571.6 251.47L488 182.56V44.05a12 12 0 0 0-12-12h-56a12 12 0 0 0-12 12v72.61L318.47 43a48 48 0 0 0-61 0L4.34 251.47a12 12 0 0 0-1.6 16.9l25.5 31A12 12 0 0 0 45.15 301l235.22-193.74a12.19 12.19 0 0 1 15.3 0L530.9 301a12 12 0 0 0 16.9-1.6l25.5-31a12 12 0 0 0-1.7-16.93z" fill="currentColor" /></svg></div>
                         <h3>Desde tu espacio seguro</h3>
                         <p>Tu casa, tu ambiente, tu comodidad. No necesitas desplazarte ni perder tiempo en la sala de espera. La terapia llega a ti, estés donde estés.</p>
                     </div>
                     <div class="info-card">
-                        <div class="icon-wrapper"><img src="icons/calendar-alt.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false"><path d="M0 464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V192H0v272zm320-196c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zM192 268c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zM64 268c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H76c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H76c-6.6 0-12-5.4-12-12v-40zM400 64h-48V16c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v48H160V16c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v48H48C21.5 64 0 85.5 0 112v48h448v-48c0-26.5-21.5-48-48-48z" fill="currentColor" /></svg></div>
                         <h3>Horarios que se ajustan a tu vida</h3>
                         <p>Mañanas, tardes, incluso fines de semana si es necesario. Nos adaptamos a tu agenda laboral, familiar o personal. Sin rigidez, con flexibilidad real.</p>
                     </div>
                     <div class="info-card">
-                        <div class="icon-wrapper"><img src="icons/globe.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false"><path d="M415.9 344L225 344C227.9 408.5 242.2 467.9 262.5 511.4C273.9 535.9 286.2 553.2 297.6 563.8C308.8 574.3 316.5 576 320.5 576C324.5 576 332.2 574.3 343.4 563.8C354.8 553.2 367.1 535.8 378.5 511.4C398.8 467.9 413.1 408.5 416 344zM224.9 296L415.8 296C413 231.5 398.7 172.1 378.4 128.6C367 104.2 354.7 86.8 343.3 76.2C332.1 65.7 324.4 64 320.4 64C316.4 64 308.7 65.7 297.5 76.2C286.1 86.8 273.8 104.2 262.4 128.6C242.1 172.1 227.8 231.5 224.9 296zM176.9 296C180.4 210.4 202.5 130.9 234.8 78.7C142.7 111.3 74.9 195.2 65.5 296L176.9 296zM65.5 344C74.9 444.8 142.7 528.7 234.8 561.3C202.5 509.1 180.4 429.6 176.9 344L65.5 344zM463.9 344C460.4 429.6 438.3 509.1 406 561.3C498.1 528.6 565.9 444.8 575.3 344L463.9 344zM575.3 296C565.9 195.2 498.1 111.3 406 78.7C438.3 130.9 460.4 210.4 463.9 296L575.3 296z" fill="currentColor" /></svg></div>
                         <h3>Sin barreras geográficas</h3>
                         <p>Vives lejos de Roses, viajas frecuentemente o simplemente prefieres la comodidad del online. La distancia física ya no es un obstáculo para cuidar de tu salud mental.</p>
                     </div>
@@ -323,8 +325,12 @@
                             </div>
                         </div>
                     </div>
-                    <button class="slider-btn prev-btn" aria-label="Reseña anterior"><img src="icons/chevron-left.svg" class="icon" alt=""></button>
-                    <button class="slider-btn next-btn" aria-label="Siguiente reseña"><img src="icons/chevron-right.svg" class="icon" alt=""></button>
+                    <button class="slider-btn prev-btn" aria-label="Reseña anterior"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M224 32a24 24 0 0 1 0 34L82.5 208 224 346a24 24 0 1 1-34 34l-160-160a24 24 0 0 1 0-34l160-160A24 24 0 0 1 224 32Z" fill="currentColor" />
+</svg></button>
+                    <button class="slider-btn next-btn" aria-label="Siguiente reseña"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0l160 160a24 24 0 0 1 0 34l-160 160a24 24 0 0 1-34-34L173.5 208 32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></button>
                 </div>
                 
                 <div class="slider-pagination" id="slider-pagination"></div>
@@ -349,10 +355,18 @@
                     <div class="price">55€</div>
                     <p class="duration">55 minutos</p>
                     <ul>
-                        <li><img src="icons/check.svg" class="icon" alt=""> Comodidad desde tu hogar</li>
-                        <li><img src="icons/check.svg" class="icon" alt=""> Misma eficacia que la presencial</li>
-                        <li><img src="icons/check.svg" class="icon" alt=""> Flexibilidad horaria total</li>
-                        <li><img src="icons/check.svg" class="icon" alt=""> Pago seguro por Bizum o transferencia</li>
+                        <li><span class="text-earth"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
+</svg></span> Comodidad desde tu hogar</li>
+                        <li><span class="text-earth"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
+</svg></span> Misma eficacia que la presencial</li>
+                        <li><span class="text-earth"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
+</svg></span> Flexibilidad horaria total</li>
+                        <li><span class="text-earth"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
+</svg></span> Pago seguro por Bizum o transferencia</li>
                     </ul>
                     <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20cita%20para%20una%20sesión%20online." target="_blank" class="btn btn-primary">Reservar Sesión Online</a>
                 </div>
@@ -368,23 +382,33 @@
                 </div>
                 <div class="faq-list" style="max-width: 800px; margin: 0 auto;">
                     <div class="faq-item">
-                        <div class="faq-question"><span>¿Qué necesito para una sesión online?</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Qué necesito para una sesión online?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>Solo necesitas un ordenador, tablet o móvil con conexión a internet, cámara y micrófono. Usamos Google Meet, que no requiere instalación. Te envío el enlace antes de cada sesión y simplemente clicas para entrar.</p></div>
                     </div>
                     <div class="faq-item">
-                        <div class="faq-question"><span>¿Es segura y confidencial la videollamada?</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Es segura y confidencial la videollamada?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>Absolutamente. Uso plataformas seguras y cifradas. Además, la confidencialidad está garantizada por el código deontológico del colegio de psicólogos, igual que en terapia presencial.</p></div>
                     </div>
                      <div class="faq-item">
-                        <div class="faq-question"><span>¿Cómo se realiza el pago de las sesiones online?</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Cómo se realiza el pago de las sesiones online?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>El pago se puede realizar cómodamente por Bizum o transferencia bancaria antes de la sesión. Te facilitaré los datos una vez acordemos la cita.</p></div>
                     </div>
                      <div class="faq-item">
-                        <div class="faq-question"><span>¿Qué pasa si tengo problemas técnicos durante la sesión?</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Qué pasa si tengo problemas técnicos durante la sesión?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>No te preocupes, estas cosas pasan. Si se cae la conexión, simplemente volvemos a conectar. Si el problema persiste, reprogramamos la sesión sin coste adicional.</p></div>
                     </div>
                      <div class="faq-item">
-                        <div class="faq-question"><span>¿Puedo combinar sesiones online y presenciales?</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Puedo combinar sesiones online y presenciales?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>Por supuesto. Muchos clientes empiezan online y luego vienen presencialmente, o al revés. O combinan según su disponibilidad. Tú decides lo que mejor te venga en cada momento.</p></div>
                     </div>
                 </div>
@@ -427,13 +451,13 @@
                 <h4>Contacto</h4>
                 <ul>
                     <li>
-                        <img src="icons/map-marker-alt.svg" class="icon" style="margin-right: 0.5rem;" alt="">
+                        <span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z" fill="currentColor" /></svg></span>
                         <a href="https://maps.app.goo.gl/qK8TCrotW8m6P8oCA" target="_blank" rel="noopener">
                             Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses
                         </a>
                     </li>
-                    <li><a href="tel:+34621372442"><img src="icons/phone.svg" class="icon" style="margin-right: 0.5rem;" alt="Teléfono">621 372 442</a></li>
-                    <li><a href="mailto:javicaceres@cop.es"><img src="icons/envelope.svg" class="icon" style="margin-right: 0.5rem;" alt="Correo">javicaceres@cop.es</a></li>
+                    <li><a href="tel:+34621372442"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Teléfono" focusable="false"><path d="M224.2 89C216.3 70.1 195.7 60.1 176.1 65.4L170.6 66.9C106 84.5 50.8 147.1 66.9 223.3C104 398.3 241.7 536 416.7 573.1C493 589.3 555.5 534 573.1 469.4L574.6 463.9C580 444.2 569.9 423.6 551.1 415.8L453.8 375.3C437.3 368.4 418.2 373.2 406.8 387.1L368.2 434.3C297.9 399.4 241.3 341 208.8 269.3L253 233.3C266.9 222 271.6 202.9 264.8 186.3L224.2 89z" fill="currentColor" /></svg></span>621 372 442</a></li>
+                    <li><a href="mailto:javicaceres@cop.es"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Correo" focusable="false"><path d="M112 128C85.5 128 64 149.5 64 176C64 191.1 71.1 205.3 83.2 214.4L291.2 370.4C308.3 383.2 331.7 383.2 348.8 370.4L556.8 214.4C568.9 205.3 576 191.1 576 176C576 149.5 554.5 128 528 128L112 128zM64 260L64 448C64 483.3 92.7 512 128 512L512 512C547.3 512 576 483.3 576 448L576 260L377.6 408.8C343.5 434.4 296.5 434.4 262.4 408.8L64 260z" fill="currentColor" /></svg></span>javicaceres@cop.es</a></li>
                 </ul>
             </div>
             <div class="footer-col">

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -152,7 +152,9 @@
                 <li><a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" class="btn btn-primary">Pedir Cita</a></li>
             </ul>
             <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
-                <img src="icons/bars.svg" class="icon" alt="">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M16 96a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32A16 16 0 0 1 16 96Zm0 160a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32a16 16 0 0 1-16-16Zm16 144a16 16 0 0 0 0 32h384a16 16 0 0 0 0-32H32Z" fill="currentColor" />
+</svg>
             </button>
         </nav>
     </header>
@@ -191,12 +193,12 @@
                 </div>
                 <div class="grid-2">
                     <div class="content-card">
-                        <div class="icon-wrapper"><img src="icons/microscope.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false"><path d="M240 64C213.5 64 192 85.5 192 112L192 320C192 346.5 213.5 368 240 368L304 368C330.5 368 352 346.5 352 320L352 256L384 256C454.7 256 512 313.3 512 384C512 454.7 454.7 512 384 512L96 512C78.3 512 64 526.3 64 544C64 561.7 78.3 576 96 576L544 576C561.7 576 576 561.7 576 544C576 526.3 561.7 512 544 512L527.1 512C557.5 478 576 433.2 576 384C576 278 490 192 384 192L352 192L352 112C352 85.5 330.5 64 304 64L240 64zM184 416C170.7 416 160 426.7 160 440C160 453.3 170.7 464 184 464L360 464C373.3 464 384 453.3 384 440C384 426.7 373.3 416 360 416L184 416z" fill="currentColor" /></svg></div>
                         <h3>El Método Gottman: La Ciencia de las Parejas</h3>
                         <p>No trabajaremos con opiniones, sino con décadas de investigación científica. El Dr. John Gottman identificó los pilares que sostienen a las parejas felices. Aprenderemos a desactivar los "Cuatro Jinetes del Apocalipsis" (crítica, desprecio, actitud defensiva y evasión) y a construir una base sólida de amistad, admiración y propósito compartido.</p>
                     </div>
                     <div class="content-card">
-                        <div class="icon-wrapper"><img src="icons/hands-helping.svg" class="icon" alt=""></div>
+                        <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" class="icon" aria-hidden="true" focusable="false"><path d="M488 192H336v56c0 39.7-32.3 72-72 72s-72-32.3-72-72V126.4l-64.9 39C107.8 176.9 96 197.8 96 220.2v47.3l-80 46.2C.7 322.5-4.6 342.1 4.3 357.4l80 138.6c8.8 15.3 28.4 20.5 43.7 11.7L231.4 448H368c35.3 0 64-28.7 64-64h16c17.7 0 32-14.3 32-32v-64h8c13.3 0 24-10.7 24-24v-48c0-13.3-10.7-24-24-24zm147.7-37.4L555.7 16C546.9.7 527.3-4.5 512 4.3L408.6 64H306.4c-12 0-23.7 3.4-33.9 9.7L239 94.6c-9.4 5.8-15 16.1-15 27.1V248c0 22.1 17.9 40 40 40s40-17.9 40-40v-88h184c30.9 0 56 25.1 56 56v28.5l80-46.2c15.3-8.9 20.5-28.4 11.7-43.7z" fill="currentColor" /></svg></div>
                         <h3>Terapia Sistémica Breve: Vuestras Soluciones</h3>
                         <p>Cada pareja es un mundo. No hay recetas mágicas. Mi papel es ayudaros a descubrir qué es lo que SÍ funciona entre vosotros (aunque ahora parezca poco) y a amplificarlo. Identificaremos los patrones que os bloquean y, juntos, diseñaremos pequeños cambios que generen grandes diferencias.</p>
                     </div>
@@ -293,8 +295,12 @@
                             </div>
                         </div>
                     </div>
-                    <button class="slider-btn prev-btn" aria-label="Reseña anterior"><img src="icons/chevron-left.svg" class="icon" alt=""></button>
-                    <button class="slider-btn next-btn" aria-label="Siguiente reseña"><img src="icons/chevron-right.svg" class="icon" alt=""></button>
+                    <button class="slider-btn prev-btn" aria-label="Reseña anterior"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M224 32a24 24 0 0 1 0 34L82.5 208 224 346a24 24 0 1 1-34 34l-160-160a24 24 0 0 1 0-34l160-160A24 24 0 0 1 224 32Z" fill="currentColor" />
+</svg></button>
+                    <button class="slider-btn next-btn" aria-label="Siguiente reseña"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 512" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0l160 160a24 24 0 0 1 0 34l-160 160a24 24 0 0 1-34-34L173.5 208 32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></button>
                 </div>
                 
                 <div class="slider-pagination" id="slider-pagination"></div>
@@ -357,23 +363,33 @@
                 </div>
                 <div class="faq-list" style="max-width: 800px; margin: 0 auto;">
                     <div class="faq-item">
-                        <div class="faq-question"><span>¿Y si mi pareja no quiere venir a terapia?</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Y si mi pareja no quiere venir a terapia?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>Es muy habitual. A veces, empezar una persona sola puede generar cambios que animen al otro a unirse. También podemos tener una primera sesión informativa para que la parte más escéptica conozca el método y resuelva sus dudas sin compromiso. No es un juicio, es un taller de mejora.</p></div>
                     </div>
                     <div class="faq-item">
-                        <div class="faq-question"><span>¿La terapia consiste en buscar culpables?</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿La terapia consiste en buscar culpables?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>Todo lo contrario. El enfoque Gottman no busca culpables, sino que analiza los patrones de interacción que no funcionan. El "enemigo" no es tu pareja, es el patrón de comunicación negativo. Trabajaremos como un equipo contra ese patrón.</p></div>
                     </div>
                      <div class="faq-item">
-                        <div class="faq-question"><span>¿Y si nuestros problemas son por una infidelidad?</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Y si nuestros problemas son por una infidelidad?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>Una infidelidad es una de las crisis más dolorosas, pero no siempre significa el final. El método proporciona un proceso estructurado para abordar la traición, procesar el dolor y, si ambos lo decidís, trabajar en la reconstrucción de la confianza.</p></div>
                     </div>
                      <div class="faq-item">
-                        <div class="faq-question"><span>¿Hablaremos solo de problemas?</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Hablaremos solo de problemas?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>No. De hecho, una parte importante del método Gottman se centra en redescubrir y fortalecer vuestra amistad, admiración y los aspectos positivos de la relación. Hablaremos de lo que os duele, pero también de lo que os une y os hizo felices.</p></div>
                     </div>
                      <div class="faq-item">
-                        <div class="faq-question"><span>¿Nos "obligarás" a seguir juntos?</span><img src="icons/chevron-down.svg" class="icon" alt=""></div>
+                        <div class="faq-question"><span>¿Nos "obligarás" a seguir juntos?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
                         <div class="faq-answer"><p>Mi rol no es decidir el futuro de vuestra relación. Mi objetivo es daros las herramientas para que os comuniquéis mejor y podáis tomar la decisión que sea mejor para vosotros, ya sea juntos o por separado, pero desde un lugar de mayor comprensión y menos dolor.</p></div>
                     </div>
                 </div>
@@ -416,13 +432,13 @@
                 <h4>Contacto</h4>
                 <ul>
                     <li>
-                        <img src="icons/map-marker-alt.svg" class="icon" style="margin-right: 0.5rem;" alt="">
+                        <span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z" fill="currentColor" /></svg></span>
                         <a href="https://maps.app.goo.gl/qK8TCrotW8m6P8oCA" target="_blank" rel="noopener">
                             Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses
                         </a>
                     </li>
-                    <li><a href="tel:+34621372442"><img src="icons/phone.svg" class="icon" style="margin-right: 0.5rem;" alt="Teléfono">621 372 442</a></li>
-                    <li><a href="mailto:javicaceres@cop.es"><img src="icons/envelope.svg" class="icon" style="margin-right: 0.5rem;" alt="Correo">javicaceres@cop.es</a></li>
+                    <li><a href="tel:+34621372442"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Teléfono" focusable="false"><path d="M224.2 89C216.3 70.1 195.7 60.1 176.1 65.4L170.6 66.9C106 84.5 50.8 147.1 66.9 223.3C104 398.3 241.7 536 416.7 573.1C493 589.3 555.5 534 573.1 469.4L574.6 463.9C580 444.2 569.9 423.6 551.1 415.8L453.8 375.3C437.3 368.4 418.2 373.2 406.8 387.1L368.2 434.3C297.9 399.4 241.3 341 208.8 269.3L253 233.3C266.9 222 271.6 202.9 264.8 186.3L224.2 89z" fill="currentColor" /></svg></span>621 372 442</a></li>
+                    <li><a href="mailto:javicaceres@cop.es"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Correo" focusable="false"><path d="M112 128C85.5 128 64 149.5 64 176C64 191.1 71.1 205.3 83.2 214.4L291.2 370.4C308.3 383.2 331.7 383.2 348.8 370.4L556.8 214.4C568.9 205.3 576 191.1 576 176C576 149.5 554.5 128 528 128L112 128zM64 260L64 448C64 483.3 92.7 512 128 512L512 512C547.3 512 576 483.3 576 448L576 260L377.6 408.8C343.5 434.4 296.5 434.4 262.4 408.8L64 260z" fill="currentColor" /></svg></span>javicaceres@cop.es</a></li>
                 </ul>
             </div>
             <div class="footer-col">


### PR DESCRIPTION
## Resumen
- Convertir los iconos locales en línea para que hereden el color del texto mediante las nuevas utilidades `text-primary` y `text-earth`.
- Actualizar los estilos globales para centralizar la paleta (`--primary`, `--earth`) y asegurar la compatibilidad con los iconos integrados.

## Archivos modificados
- css/styles.css
- css/legal-styles.css
- index.html
- terapia-online.html
- terapia-pareja.html
- aviso-legal.html
- politica-privacidad.html
- politica-cookies.html
- codigo-deontologico.html

## Iconos convertidos
- `bars.svg`
- `comments.svg`, `brain.svg`, `heart.svg`, `handshake-angle.svg`, `rocket.svg`, `lightbulb.svg`, `bullseye.svg`, `forward.svg`, `user-friends.svg`, `comment-dots.svg`, `calendar-check.svg`, `route.svg`, `home.svg`, `calendar-alt.svg`, `globe.svg`, `microscope.svg`, `hands-helping.svg`
- `check.svg`
- `chevron-left.svg`, `chevron-right.svg`, `chevron-down.svg`
- `map-marker-alt.svg`, `phone.svg`, `envelope.svg`
- `file-pdf.svg`

> Nota: Los iconos de WhatsApp y las estrellas de valoración permanecen como imágenes para conservar su color de marca.

------
https://chatgpt.com/codex/tasks/task_e_68e19ebc11ac832587f4afed02e0aafe