### PR TITLE
Add explicit dimensions to icon imagery

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -332,8 +332,6 @@ section#especializacion .grid-2 > a {
 }
 
 .icon {
-    width: 1em;
-    height: 1em;
     vertical-align: middle;
 }
 
@@ -346,8 +344,6 @@ section#especializacion .grid-2 > a {
 }
 
 .rating .icon {
-    width: 1.1em;
-    height: 1.1em;
     vertical-align: middle;
     line-height: 1;
 }

--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@
                 <h1>¿La ansiedad o la tristeza te están alejando de la vida que deseas?</h1>
                 <p class="subtitle">No tienes por qué seguir así. Te ofrezco una terapia breve y colaborativa, un espacio de confianza donde, juntos, encontraremos tus recursos para que recuperes la calma, la claridad y el control.</p>
                 <div class="hero-actions">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20para%20una%20cita%20presencial." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp"> Contactar por WhatsApp</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20para%20una%20cita%20presencial." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Contactar por WhatsApp</a>
                     <a href="#tarifas" class="btn btn-secondary">Ver Tarifas</a>
                 </div>
             </div>
@@ -382,42 +382,42 @@
                     <div class="testimonial-slider">
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>Gran profesional me ha ayudado a saber gestionarme y guiarme. Muy recomendable un 10.</blockquote>
                                 <cite>C.M.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>Un profesional excelente. Estoy muy agradecida con Javi por su profesionalidad y empatía. Desde el primer momento me hizo sentir cómoda y comprendida, creando un espacio seguro donde trabajar en mi bienestar.</blockquote>
                                 <cite>Dra. M.L.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>Estoy muy contenta. Totalmente recomendable. Es profesional pero también muy cercano. Me ha ayudado a encontrar y desarrollar métodos adecuados a mi personalidad para tratar mi problema.</blockquote>
                                 <cite>C.G.M.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>Javi me ha ayudado a salir de un período bastante complicado. Estoy muy contento con el proceso y el acompañamiento. El trato es cercano, amable y sincero.</blockquote>
                                 <cite>P.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>...me ha sabido escuchar y comprender en todo momento; me ha facilitado herramientas y estrategias para abordar las dificultades diarias que surgen a menudo...</blockquote>
                                 <cite>E.F.M.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>...escucha activamente, da herramientas y actividades para avanzar... Su servicio es de gran utilidad y personalmente creo que me ha ayudado a mejorar mi calidad de vida.</blockquote>
                                 <cite>M.</cite>
                             </div>
@@ -530,7 +530,7 @@
                 <h2>El cambio empieza con una conversación. ¿Hablamos?</h2>
                 <p>Dar el primer paso es el más valiente. Escríbeme sin compromiso para resolver cualquier duda o para concertar una primera cita. Estoy aquí para escucharte.</p>
                 <div class="hero-actions" style="margin-top: 2rem;">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20para%20una%20cita." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp"> Escríbeme por WhatsApp</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20para%20una%20cita." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Escríbeme por WhatsApp</a>
                 </div>
             </div>
         </section>
@@ -582,7 +582,7 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
 
-    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp"></a>
+    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"></a>
 
     <div class="cookie-consent-banner" id="cookie-banner">
         <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información</a>.</p>

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -171,7 +171,7 @@
                 <h1>¿La distancia o la falta de tiempo te impiden cuidar de tu bienestar?</h1>
                 <p class="subtitle">La terapia online te ofrece el mismo nivel de calidad y cercanía que la presencial, pero con la flexibilidad que necesitas. Desde tu casa, desde donde estés, cuando mejor te venga.</p>
                 <div class="hero-actions">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp"> Empezar Ahora</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Empezar Ahora</a>
                 </div>
             </div>
         </section>
@@ -284,42 +284,42 @@
                     <div class="testimonial-slider">
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>Gran profesional me ha ayudado a saber gestionarme y guiarme. Muy recomendable un 10.</blockquote>
                                 <cite>C.M.</cite>
                             </div>
                         </div>
                          <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>Un profesional excelente. Estoy muy agradecida con Javi por su profesionalidad y empatía. Desde el primer momento me hizo sentir cómoda y comprendida, creando un espacio seguro donde trabajar en mi bienestar.</blockquote>
                                 <cite>Dra. M.L.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>Estoy muy contenta. Totalmente recomendable. Es profesional pero también muy cercano. Me ha ayudado a encontrar y desarrollar métodos adecuados a mi personalidad para tratar mi problema.</blockquote>
                                 <cite>C.G.M.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>Javi me ha ayudado a salir de un período bastante complicado. Estoy muy contento con el proceso y el acompañamiento. El trato es cercano, amable y sincero.</blockquote>
                                 <cite>P.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>...me ha sabido escuchar y comprender en todo momento; me ha facilitado herramientas y estrategias para abordar las dificultades diarias que surgen a menudo...</blockquote>
                                 <cite>E.F.M.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>...escucha activamente, da herramientas y actividades para avanzar... Su servicio es de gran utilidad y personalmente creo que me ha ayudado a mejorar mi calidad de vida.</blockquote>
                                 <cite>M.</cite>
                             </div>
@@ -421,7 +421,7 @@
                 <h2>Tu bienestar no puede esperar. Empieza hoy.</h2>
                 <p>No dejes que la falta de tiempo o la ubicación sean un obstáculo para sentirte mejor. La terapia breve online es una puerta abierta a tu cambio personal. ¿Hablamos?</p>
                 <div class="hero-actions" style="margin-top: 2rem;">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp"> Empezar Terapia Online</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Empezar Terapia Online</a>
                 </div>
             </div>
         </section>
@@ -473,7 +473,7 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
 
-    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp"></a>
+    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"></a>
 
     <div class="cookie-consent-banner" id="cookie-banner">
         <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información</a>.</p>

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -179,7 +179,7 @@
                 <h1>¿Sentís que la distancia y las discusiones se han adueñado de vuestra relación?</h1>
                 <p class="subtitle">Recuperar la conexión, la amistad y la pasión es posible. Os ofrezco un método de terapia de pareja basado en la ciencia (Gottman) y en vuestras propias fortalezas para reconstruir el "nosotros" que un día fuisteis.</p>
                 <div class="hero-actions">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp"> Iniciar el Cambio</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Iniciar el Cambio</a>
                 </div>
             </div>
         </section>
@@ -254,42 +254,42 @@
                     <div class="testimonial-slider">
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>Gran profesional me ha ayudado a saber gestionarme y guiarme. Muy recomendable un 10.</blockquote>
                                 <cite>C.M.</cite>
                             </div>
                         </div>
                          <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>Un profesional excelente. Estoy muy agradecida con Javi por su profesionalidad y empatía. Desde el primer momento me hizo sentir cómoda y comprendida, creando un espacio seguro donde trabajar en mi bienestar.</blockquote>
                                 <cite>Dra. M.L.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>Estoy muy contenta. Totalmente recomendable. Es profesional pero también muy cercano. Me ha ayudado a encontrar y desarrollar métodos adecuados a mi personalidad para tratar mi problema.</blockquote>
                                 <cite>C.G.M.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>Javi me ha ayudado a salir de un período bastante complicado. Estoy muy contento con el proceso y el acompañamiento. El trato es cercano, amable y sincero.</blockquote>
                                 <cite>P.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>...me ha sabido escuchar y comprender en todo momento; me ha facilitado herramientas y estrategias para abordar las dificultades diarias que surgen a menudo...</blockquote>
                                 <cite>E.F.M.</cite>
                             </div>
                         </div>
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
-                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"><img src="icons/star-rating.svg" class="icon" alt="Estrella"></div>
+                                <div class="stars rating"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"><img src="icons/star-rating.svg" class="icon" alt="Estrella" width="18" height="18" decoding="async"></div>
                                 <blockquote>...escucha activamente, da herramientas y actividades para avanzar... Su servicio es de gran utilidad y personalmente creo que me ha ayudado a mejorar mi calidad de vida.</blockquote>
                                 <cite>M.</cite>
                             </div>
@@ -402,7 +402,7 @@
                 <h2>Construid el futuro que deseáis, juntos.</h2>
                 <p>Dar el paso de pedir ayuda como pareja es un acto de valentía y un gran gesto de amor hacia la relación. Si estáis listos para empezar a cambiar las cosas, estoy aquí para guiaros.</p>
                 <div class="hero-actions" style="margin-top: 2rem;">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp"> Contactar para Terapia de Pareja</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Contactar para Terapia de Pareja</a>
                 </div>
             </div>
         </section>
@@ -454,7 +454,7 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
 
-    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp"></a>
+    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"></a>
 
     <div class="cookie-consent-banner" id="cookie-banner">
         <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información</a>.</p>


### PR DESCRIPTION
## Summary
- add explicit width, height, and async decoding attributes to WhatsApp CTAs, testimonial stars, and footer icons across the marketing pages
- remove fixed CSS sizing so HTML attributes determine rendered dimensions for inline icons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1aa2c6b5883258f5a8cd556bc90b2