### PR TITLE
Refactor shared CSS into a reusable base module

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -1,0 +1,361 @@
+/* Base shared styles for the site */
+:root {
+    --accent-empathy: #D97757;
+    --accent-wisdom: #6B7A99;
+    --primary: var(--accent-wisdom);
+    --earth: var(--accent-empathy);
+    --text-strongest: #2D3748;
+    --text-strong: #4A5568;
+    --text-medium: #6C7A90;
+    --bg-subtle: #E4E7EB;
+    --bg-lighter: #F1F0EC;
+    --bg-main: #F9F9F7;
+    --white: #FFFFFF;
+    --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.04);
+    --shadow-md: 0 2px 8px -2px rgb(0 0 0 / 0.08);
+    --shadow-lg: 0 8px 24px -4px rgb(0 0 0 / 0.12);
+    --border-width: 1px;
+    --border-accent: 2px;
+    --radius: 12px;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    font-family: 'Inter', sans-serif;
+    background-color: var(--bg-main);
+    color: var(--text-strong);
+    line-height: 1.7;
+    font-size: 17px;
+}
+
+.container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+}
+
+h1,
+h2,
+h3,
+h4 {
+    color: var(--text-strongest);
+    line-height: 1.25;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+}
+
+h1 {
+    font-size: clamp(2.4rem, 5vw, 3.2rem);
+}
+
+h2 {
+    font-size: clamp(2rem, 4vw, 2.8rem);
+}
+
+h3 {
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+p {
+    margin-bottom: 1.2rem;
+    max-width: 65ch;
+    line-height: 1.7;
+    color: var(--text-strong);
+}
+
+a {
+    color: var(--accent-empathy);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+ul {
+    list-style-position: outside;
+    padding-left: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+li {
+    margin-bottom: 0.5rem;
+    color: var(--text-strong);
+}
+
+strong {
+    color: var(--text-strongest);
+}
+
+.section {
+    padding: clamp(4.5rem, 10vw, 7rem) 0;
+}
+
+.section-header {
+    text-align: center;
+    max-width: 750px;
+    margin: 0 auto 4rem auto;
+}
+
+.section-subtitle {
+    color: var(--accent-wisdom);
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    letter-spacing: 0.1em;
+    text-align: center;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.section-title {
+    margin-bottom: 1.5rem;
+    max-width: 28ch;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.section-header p {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+/* Header and navigation */
+.header {
+    background: rgba(249, 249, 247, 0.75);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    position: fixed;
+    width: 100%;
+    z-index: 100;
+    border-bottom: var(--border-width) solid transparent;
+    transition: background 0.3s, border-color 0.3s, box-shadow 0.3s;
+}
+
+.header.scrolled {
+    background: rgba(249, 249, 247, 0.85);
+    border-bottom-color: rgba(228, 231, 235, 0.3);
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
+}
+
+.nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.2rem 1.5rem;
+}
+
+.nav-menu {
+    display: none;
+    list-style: none;
+    gap: 1.8rem;
+    align-items: center;
+}
+
+.nav-menu a {
+    color: var(--text-strong);
+    transition: color 0.2s;
+    font-weight: 600;
+}
+
+.nav-menu a:not(.btn):hover {
+    color: var(--accent-empathy);
+}
+
+.hamburger-menu {
+    display: block;
+    font-size: 1.5rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-strongest);
+    z-index: 101;
+}
+
+.mobile-nav-panel {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: var(--bg-main);
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transform: translateY(-20px);
+    transition: opacity 0.3s, transform 0.3s;
+    pointer-events: none;
+    z-index: 100;
+}
+
+.mobile-nav-panel.active {
+    display: flex;
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
+.mobile-nav-panel ul {
+    list-style: none;
+    text-align: center;
+}
+
+.mobile-nav-panel ul li {
+    margin-bottom: 2.5rem;
+}
+
+.mobile-nav-panel ul a {
+    font-size: 1.8rem;
+    font-weight: 600;
+    color: var(--text-strongest);
+}
+
+/* Logo */
+.logo-container {
+    display: flex;
+    align-items: center;
+    width: 240px;
+    height: 70px;
+}
+
+.logo-img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+/* Buttons */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.875rem 1.75rem;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    transition: all 0.2s ease;
+    border: none;
+    cursor: pointer;
+    gap: 0.5rem;
+    letter-spacing: 0.01em;
+}
+
+.btn-primary {
+    background-color: var(--accent-empathy);
+    color: var(--white);
+    box-shadow: var(--shadow-sm);
+}
+
+.btn-primary:hover {
+    background-color: #c86644;
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+    color: var(--white) !important;
+}
+
+.btn-secondary {
+    background-color: var(--white);
+    color: var(--text-strong);
+    border: var(--border-width) solid var(--bg-subtle);
+    box-shadow: var(--shadow-sm);
+}
+
+.btn-secondary:hover {
+    background-color: var(--bg-lighter);
+    border-color: var(--accent-wisdom);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+}
+
+.icon {
+    width: 1em;
+    height: 1em;
+    vertical-align: middle;
+}
+
+.text-primary {
+    color: var(--primary);
+}
+
+.text-earth {
+    color: var(--earth);
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+/* Footer */
+.footer {
+    background-color: var(--bg-lighter);
+    padding: 4rem 0;
+}
+
+.footer-grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.footer-col h4 {
+    margin-bottom: 1rem;
+}
+
+.footer-col p,
+.footer-col li,
+.footer-col a {
+    font-size: 0.95rem;
+    color: var(--text-medium);
+}
+
+.footer-col ul {
+    list-style: none;
+    padding-left: 0;
+}
+
+.footer-col li {
+    margin-bottom: 0.5rem;
+}
+
+.footer-col a:hover {
+    text-decoration: underline;
+    color: var(--accent-empathy);
+}
+
+.footer-bottom {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--bg-subtle);
+    text-align: center;
+    font-size: 0.9rem;
+    color: var(--text-medium);
+}
+
+@media (min-width: 992px) {
+    .nav-menu {
+        display: flex;
+    }
+
+    .hamburger-menu {
+        display: none;
+    }
+}
+
+@media (max-width: 768px) {
+    .logo-container {
+        width: 180px;
+        height: 50px;
+    }
+}

--- a/css/legal-styles.css
+++ b/css/legal-styles.css
@@ -1,182 +1,6 @@
-.icon {
-    width: 1em;
-    height: 1em;
-    vertical-align: middle;
-}
+@import url('./base.css');
 
-.text-primary {
-    color: var(--primary);
-}
-
-.text-earth {
-    color: var(--earth);
-}
-
-/* ESTILOS PARA PÁGINAS LEGALES */
-:root {
-    --accent-empathy: #D97757;
-    --accent-wisdom: #6B7A99;
-    --primary: var(--accent-wisdom);
-    --earth: var(--accent-empathy);
-    --text-strongest: #2D3748;
-    --text-strong: #4A5568;
-    --text-medium: #6C7A90;
-    --bg-subtle: #E4E7EB;
-    --bg-lighter: #F1F0EC;
-    --bg-main: #F9F9F7;
-    --white: #FFFFFF;
-    --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.04);
-    --shadow-md: 0 2px 8px -2px rgb(0 0 0 / 0.08);
-    --shadow-lg: 0 8px 24px -4px rgb(0 0 0 / 0.12);
-    --border-width: 1px;
-    --radius: 12px;
-}
-
-* { margin: 0; padding: 0; box-sizing: border-box; }
-html { scroll-behavior: smooth; }
-body {
-    font-family: 'Inter', sans-serif;
-    background-color: var(--bg-main);
-    color: var(--text-strong);
-    line-height: 1.7;
-    font-size: 17px;
-}
-
-.container { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem; }
-
-h1, h2, h3, h4 {
-    color: var(--text-strongest);
-    line-height: 1.25;
-    font-weight: 700;
-    letter-spacing: -0.02em;
-}
-h1 { font-size: clamp(2.4rem, 5vw, 3.2rem); }
-h2 { font-size: clamp(1.8rem, 4vw, 2.4rem); margin-top: 3rem; }
-h3 { font-size: 1.25rem; font-weight: 600; margin-top: 2rem; }
-
-p {
-    margin-bottom: 1.2rem;
-    max-width: 75ch;
-    line-height: 1.7;
-    color: var(--text-strong);
-}
-
-a { color: var(--accent-empathy); text-decoration: none; font-weight: 600; }
-a:hover { text-decoration: underline; }
-
-ul {
-    list-style-position: outside;
-    padding-left: 1.5rem;
-    margin-bottom: 1.5rem;
-}
-
-li {
-    margin-bottom: 0.5rem;
-    color: var(--text-strong);
-}
-
-strong { color: var(--text-strongest); }
-
-/* HEADER */
-.header {
-    background: rgba(249, 249, 247, 0.75);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    position: fixed;
-    width: 100%;
-    z-index: 100;
-    border-bottom: var(--border-width) solid transparent;
-    transition: background 0.3s, border-color 0.3s, box-shadow 0.3s;
-}
-
-.header.scrolled {
-    background: rgba(249, 249, 247, 0.85);
-    border-bottom-color: rgba(228, 231, 235, 0.3);
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
-}
-
-.nav {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1.2rem 1.5rem;
-}
-
-.logo-container {
-    display: flex;
-    align-items: center;
-}
-
-.logo-img { 
-    height: 70px;
-    width: auto;
-}
-
-.nav-menu {
-    display: none;
-    list-style: none;
-    gap: 1.8rem;
-    align-items: center;
-}
-
-.nav-menu a {
-    color: var(--text-strong);
-    transition: color 0.2s;
-    font-weight: 600;
-}
-
-.nav-menu a:hover { color: var(--accent-empathy); text-decoration: none; }
-
-.hamburger-menu {
-    display: block;
-    font-size: 1.5rem;
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--text-strongest);
-    z-index: 101;
-}
-
-.mobile-nav-panel {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: var(--bg-main);
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    opacity: 0;
-    transform: translateY(-20px);
-    transition: opacity 0.3s, transform 0.3s;
-    pointer-events: none;
-    z-index: 100;
-}
-
-.mobile-nav-panel.active {
-    display: flex;
-    opacity: 1;
-    transform: translateY(0);
-    pointer-events: auto;
-}
-
-.mobile-nav-panel ul {
-    list-style: none;
-    text-align: center;
-    padding: 0;
-}
-
-.mobile-nav-panel ul li { margin-bottom: 2.5rem; }
-
-.mobile-nav-panel ul a {
-    font-size: 1.8rem;
-    font-weight: 600;
-    color: var(--text-strongest);
-}
-
-/* CONTENIDO LEGAL */
+/* Overrides specific to legal pages */
 .legal-content {
     padding-top: 10rem;
     padding-bottom: 5rem;
@@ -192,13 +16,24 @@ strong { color: var(--text-strongest); }
 }
 
 .legal-content h2 {
+    font-size: clamp(1.8rem, 4vw, 2.4rem);
     border-bottom: 2px solid var(--accent-wisdom);
     padding-bottom: 0.75rem;
     margin-bottom: 1.5rem;
+    margin-top: 3rem;
 }
 
 .legal-content h3 {
     color: var(--accent-empathy);
+    margin-top: 2rem;
+}
+
+.legal-content p {
+    max-width: 75ch;
+}
+
+.legal-content a:hover {
+    text-decoration: underline;
 }
 
 .owner-details,
@@ -235,90 +70,12 @@ strong { color: var(--text-strongest); }
     border-top: 1px solid var(--bg-subtle);
 }
 
-/* FOOTER */
-.footer {
-    background-color: var(--bg-lighter);
-    padding: 4rem 0;
-}
-
-.footer-grid {
-    display: grid;
-    gap: 2rem;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.footer-col h4 { margin-bottom: 1rem; }
-
-.footer-col p,
-.footer-col li,
-.footer-col a {
-    font-size: 0.95rem;
-    color: var(--text-medium);
-}
-
-.footer-col ul {
-    list-style: none;
-    padding-left: 0;
-}
-
-.footer-col li { margin-bottom: 0.5rem; }
-
-.footer-col a:hover {
-    text-decoration: underline;
-    color: var(--accent-empathy);
-}
-
-.footer-bottom {
-    margin-top: 3rem;
-    padding-top: 2rem;
-    border-top: 1px solid var(--bg-subtle);
-    text-align: center;
-    font-size: 0.9rem;
-    color: var(--text-medium);
-}
-
-/* IMATGES AMB PROPORCIO CORRECTA - FIX CLS */
-img {
-    max-width: 100%;
-    height: auto;
-}
-
-/* RESPONSIVE */
-@media (min-width: 992px) {
-    .nav-menu { display: flex; }
-    .hamburger-menu { display: none; }
-}
-
 @media (max-width: 768px) {
-    .logo-img {
-        height: 50px;
-    }
-    
     .legal-content {
         padding-top: 8rem;
     }
-    
+
     .highlight-box {
         padding: 1.5rem;
-    }
-}
-/* ===== FIX CLS - Logo (mismo que styles.css) ===== */
-.logo-container {
-    display: flex;
-    align-items: center;
-    width: 240px;
-    height: 70px;
-}
-
-.logo-img {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-}
-
-@media (max-width: 768px) {
-    .logo-container {
-        width: 180px;
-        height: 50px;
     }
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,225 +1,4 @@
-/* SISTEMA DE DISEÑO UNIFICADO Y MEJORADO */
-:root {
-    --accent-empathy: #D97757;
-    --accent-wisdom: #6B7A99;
-    --primary: var(--accent-wisdom);
-    --earth: var(--accent-empathy);
-    --text-strongest: #2D3748;
-    --text-strong: #4A5568;
-    --text-medium: #6C7A90;
-    --bg-subtle: #E4E7EB;
-    --bg-lighter: #F1F0EC;
-    --bg-main: #F9F9F7;
-    --white: #FFFFFF;
-    --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.04);
-    --shadow-md: 0 2px 8px -2px rgb(0 0 0 / 0.08);
-    --shadow-lg: 0 8px 24px -4px rgb(0 0 0 / 0.12);
-    --border-width: 1px;
-    --border-accent: 2px;
-    --radius: 12px;
-}
-
-* { margin: 0; padding: 0; box-sizing: border-box; }
-html { scroll-behavior: smooth; }
-body {
-    font-family: 'Inter', sans-serif;
-    background-color: var(--bg-main);
-    color: var(--text-strong);
-    line-height: 1.7;
-    font-size: 17px;
-}
-
-.container { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem; }
-
-h1, h2, h3, h4 {
-    color: var(--text-strongest);
-    line-height: 1.25;
-    font-weight: 700;
-    letter-spacing: -0.02em;
-}
-h1 { font-size: clamp(2.4rem, 5vw, 3.2rem); }
-h2 { font-size: clamp(2rem, 4vw, 2.8rem); }
-h3 { font-size: 1.25rem; font-weight: 600; }
-
-p {
-    margin-bottom: 1.2rem;
-    max-width: 65ch;
-    line-height: 1.7;
-    color: var(--text-strong);
-}
-
-a { color: var(--accent-empathy); text-decoration: none; font-weight: 600; }
-
-.section { padding: clamp(4.5rem, 10vw, 7rem) 0; }
-
-.section-header {
-    text-align: center;
-    max-width: 750px;
-    margin: 0 auto 4rem auto;
-}
-
-.section-subtitle {
-    color: var(--accent-wisdom);
-    font-weight: 600;
-    margin-bottom: 0.75rem;
-    text-transform: uppercase;
-    font-size: 0.85rem;
-    letter-spacing: 0.1em;
-    text-align: center;
-    display: block;
-    margin-left: auto;
-    margin-right: auto; 
-}
-
-.section-title {
-    margin-bottom: 1.5rem;
-    max-width: 28ch;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-.section-header p { margin-left: auto; margin-right: auto; }
-
-/* HEADER - Más transparente y moderno con logo más grande */
-.header {
-    background: rgba(249, 249, 247, 0.75);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    position: fixed;
-    width: 100%;
-    z-index: 100;
-    border-bottom: var(--border-width) solid transparent;
-    transition: background 0.3s, border-color 0.3s, box-shadow 0.3s;
-}
-
-.header.scrolled {
-    background: rgba(249, 249, 247, 0.85);
-    border-bottom-color: rgba(228, 231, 235, 0.3);
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
-}
-
-.nav {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1.2rem 1.5rem;
-}
-
-.logo-container {
-    display: flex;
-    align-items: center;
-}
-
-.logo-img { 
-    height: 70px;
-    width: auto;
-}
-
-.nav-menu {
-    display: none;
-    list-style: none;
-    gap: 1.8rem;
-    align-items: center;
-}
-
-.nav-menu a {
-    color: var(--text-strong);
-    transition: color 0.2s;
-    font-weight: 600;
-}
-
-.nav-menu a:not(.btn):hover { color: var(--accent-empathy); }
-
-.hamburger-menu {
-    display: block;
-    font-size: 1.5rem;
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--text-strongest);
-    z-index: 101;
-}
-
-.mobile-nav-panel {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: var(--bg-main);
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    opacity: 0;
-    transform: translateY(-20px);
-    transition: opacity 0.3s, transform 0.3s;
-    pointer-events: none;
-    z-index: 100;
-}
-
-.mobile-nav-panel.active {
-    display: flex;
-    opacity: 1;
-    transform: translateY(0);
-    pointer-events: auto;
-}
-
-.mobile-nav-panel ul {
-    list-style: none;
-    text-align: center;
-}
-
-.mobile-nav-panel ul li { margin-bottom: 2.5rem; }
-
-.mobile-nav-panel ul a {
-    font-size: 1.8rem;
-    font-weight: 600;
-    color: var(--text-strongest);
-}
-
-/* BOTONES */
-.btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.875rem 1.75rem;
-    border-radius: 8px;
-    font-weight: 600;
-    font-size: 0.95rem;
-    transition: all 0.2s ease;
-    border: none;
-    cursor: pointer;
-    gap: 0.5rem;
-    letter-spacing: 0.01em;
-}
-
-.btn-primary {
-    background-color: var(--accent-empathy);
-    color: var(--white);
-    box-shadow: var(--shadow-sm);
-}
-
-.btn-primary:hover {
-    background-color: #c86644;
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-md);
-    color: var(--white) !important;
-}
-
-.btn-secondary {
-    background-color: var(--white);
-    color: var(--text-strong);
-    border: var(--border-width) solid var(--bg-subtle);
-    box-shadow: var(--shadow-sm);
-}
-
-.btn-secondary:hover {
-    background-color: var(--bg-lighter);
-    border-color: var(--accent-wisdom);
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-md);
-}
+@import url('./base.css');
 
 /* HERO */
 .hero {
@@ -329,18 +108,6 @@ section#especializacion .grid-2 > a {
     display: flex;
     flex-direction: column;
     text-align: center;
-}
-
-.icon {
-    vertical-align: middle;
-}
-
-.text-primary {
-    color: var(--primary);
-}
-
-.text-earth {
-    color: var(--earth);
 }
 
 .rating .icon {
@@ -706,48 +473,6 @@ section#especializacion .grid-2 > a {
     margin-right: auto;
 }
 
-/* FOOTER */
-.footer {
-    background-color: var(--bg-lighter);
-    padding: 4rem 0;
-}
-
-.footer-grid {
-    display: grid;
-    gap: 2rem;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.footer-col h4 { margin-bottom: 1rem; }
-
-.footer-col p,
-.footer-col li,
-.footer-col a {
-    font-size: 0.95rem;
-    color: var(--text-medium);
-}
-
-.footer-col ul {
-    list-style: none;
-    padding-left: 0;
-}
-
-.footer-col li { margin-bottom: 0.5rem; }
-
-.footer-col a:hover {
-    text-decoration: underline;
-    color: var(--accent-empathy);
-}
-
-.footer-bottom {
-    margin-top: 3rem;
-    padding-top: 2rem;
-    border-top: 1px solid var(--bg-subtle);
-    text-align: center;
-    font-size: 0.9rem;
-    color: var(--text-medium);
-}
-
 /* WHATSAPP FLOAT */
 .whatsapp-float {
     position: fixed;
@@ -805,31 +530,12 @@ section#especializacion .grid-2 > a {
     text-decoration: underline;
 }
 
-/* IMATGES AMB PROPORCIO CORRECTA - FIX CLS */
-img {
-    max-width: 100%;
-    height: auto;
-}
-
-.about-image {
-    width: 100%;
-    max-width: 500px;
-    height: auto;
-}
-
-.space-image {
-    max-width: 800px;
-    height: auto;
-}
-
 /* RESPONSIVE */
 @media (min-width: 768px) {
     .grid-2 { grid-template-columns: 1fr 1fr; }
 }
 
 @media (min-width: 992px) {
-    .nav-menu { display: flex; }
-    .hamburger-menu { display: none; }
     .about-section { grid-template-columns: 1fr 1fr; }
     .map-section { grid-template-columns: 1fr 1fr; }
     .prev-btn { left: 15px; }
@@ -853,11 +559,7 @@ img {
     .info-card,
     .content-card,
     .tarifa-card { padding: 2rem; }
-    
-    .logo-img {
-        height: 50px;
-    }
-    
+
     .hero {
         padding-top: 8rem;
     }
@@ -884,20 +586,6 @@ img {
     .next-btn { right: 5px; }
 }
 /* ===== OPTIMIZACIONES DE RENDIMIENTO ===== */
-
-/* FIX CLS - Logo con aspect ratio reservado */
-.logo-container {
-    display: flex;
-    align-items: center;
-    width: 240px;
-    height: 70px;
-}
-
-.logo-img {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-}
 
 /* FIX CLS - Imágenes con aspect ratio */
 .about-image {
@@ -1006,11 +694,6 @@ img {
 
 /* Responsive optimizado */
 @media (max-width: 768px) {
-    .logo-container {
-        width: 180px;
-        height: 50px;
-    }
-    
     .map-placeholder {
         height: 350px;
     }


### PR DESCRIPTION
## Summary
- add css/base.css with shared variables, typography, header/navigation, button, and footer styles reused across pages
- update styles.css to import the base module and remove duplicated logo and map rules in favor of a single definition
- streamline legal-styles.css so it only overrides legal page spacing and typography after importing the shared base

## Testing
- python -m http.server 8000 (manual smoke test while browsing legal pages)
- Playwright script to open politica-privacidad.html on mobile width and verify the hamburger menu activates

------
https://chatgpt.com/codex/tasks/task_e_68e1abf81eb083259a67920f8a3a09a7