### PR TITLE
Improve testimonial carousel responsiveness

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -34,77 +34,155 @@ document.addEventListener('DOMContentLoaded', function() {
         const nextButton = document.querySelector('.next-btn');
         const prevButton = document.querySelector('.prev-btn');
         const paginationContainer = document.getElementById('slider-pagination');
+        const desktopQuery = window.matchMedia('(min-width: 992px)');
+        const tabletQuery = window.matchMedia('(min-width: 768px)');
+        const cleanupCallbacks = [];
         let currentIndex = 0;
         let intervalId;
         let slidesPerView = 1;
+        let totalPages = 0;
+        let layoutUpdateTimeoutId = null;
+        let sliderObserver;
+        let isSliderVisible = !('IntersectionObserver' in window);
 
-        const createPaginationDots = () => {
-            paginationContainer.innerHTML = '';
-            const totalDots = 4;
-            
-            for (let i = 0; i < totalDots; i++) {
-                const dot = document.createElement('button');
-                dot.classList.add('pagination-dot');
-                dot.setAttribute('aria-label', `Ir a página ${i + 1}`);
-                if (i === 0) dot.classList.add('active');
-                
-                dot.addEventListener('click', () => {
-                    currentIndex = i;
-                    showSlide(currentIndex);
-                    updatePagination();
-                    stopAutoSlide();
-                    startAutoSlide();
-                });
-                
-                paginationContainer.appendChild(dot);
+        const debounce = (fn, delay = 150) => {
+            return (...args) => {
+                if (layoutUpdateTimeoutId) {
+                    clearTimeout(layoutUpdateTimeoutId);
+                }
+                layoutUpdateTimeoutId = setTimeout(() => {
+                    layoutUpdateTimeoutId = null;
+                    fn(...args);
+                }, delay);
+            };
+        };
+
+        const calculateSlidesPerView = () => {
+            if (desktopQuery.matches) {
+                return 3;
             }
+            if (tabletQuery.matches) {
+                return 2;
+            }
+            return 1;
         };
 
         const updatePagination = () => {
+            if (!paginationContainer) return;
             const dots = paginationContainer.querySelectorAll('.pagination-dot');
-            const currentPage = Math.floor(currentIndex);
-            
+            if (!dots.length) return;
+
+            const safeIndex = Math.min(Math.max(currentIndex, 0), dots.length - 1);
             dots.forEach((dot, index) => {
-                dot.classList[index === currentPage ? 'add' : 'remove']('active');
+                dot.classList[index === safeIndex ? 'add' : 'remove']('active');
             });
         };
 
-        const updateSlidesPerView = () => {
-            if (window.innerWidth >= 992) {
-                slidesPerView = 3;
-            } else if (window.innerWidth >= 768) {
-                slidesPerView = 2;
-            } else {
-                slidesPerView = 1;
-            }
-            createPaginationDots();
-        };
+        const getMaxIndex = () => Math.max(0, totalPages - 1);
 
         const showSlide = (index) => {
+            const maxIndex = getMaxIndex();
+            currentIndex = Math.min(Math.max(index, 0), maxIndex);
             const slideWidth = 100 / slidesPerView;
             // Usar transform con will-change para mejor performance
-            slider.style.transform = `translateX(${-index * slideWidth}%)`;
+            slider.style.transform = `translateX(${-currentIndex * slideWidth}%)`;
             updatePagination();
         };
 
+        const ensurePaginationDots = () => {
+            const nextTotalPages = Math.max(1, Math.ceil(slides.length / slidesPerView));
+            const previousTotalPages = totalPages;
+            totalPages = nextTotalPages;
+
+            if (!paginationContainer) {
+                return;
+            }
+
+            const shouldRebuild = previousTotalPages !== totalPages || paginationContainer.childElementCount !== totalPages;
+
+            if (shouldRebuild) {
+                paginationContainer.innerHTML = '';
+
+                for (let i = 0; i < totalPages; i++) {
+                    const dot = document.createElement('button');
+                    dot.classList.add('pagination-dot');
+                    dot.setAttribute('aria-label', `Ir a página ${i + 1}`);
+
+                    dot.addEventListener('click', () => {
+                        currentIndex = i;
+                        showSlide(currentIndex);
+                        stopAutoSlide();
+                        startAutoSlide();
+                    });
+
+                    paginationContainer.appendChild(dot);
+                }
+            }
+
+            updatePagination();
+        };
+
+        const applySliderLayout = () => {
+            const newSlidesPerView = calculateSlidesPerView();
+            const slidesPerViewChanged = newSlidesPerView !== slidesPerView;
+            const previousTotalPages = totalPages;
+
+            slidesPerView = newSlidesPerView;
+            ensurePaginationDots();
+
+            if (currentIndex > getMaxIndex()) {
+                currentIndex = 0;
+            }
+
+            if (slidesPerViewChanged || previousTotalPages !== totalPages) {
+                showSlide(currentIndex);
+            } else {
+                updatePagination();
+            }
+        };
+
+        const scheduleLayoutUpdate = debounce(applySliderLayout, 150);
+
+        const registerMediaListener = (mediaQuery, handler) => {
+            if (!mediaQuery) return () => {};
+
+            if (typeof mediaQuery.addEventListener === 'function') {
+                mediaQuery.addEventListener('change', handler);
+                return () => mediaQuery.removeEventListener('change', handler);
+            }
+
+            mediaQuery.addListener(handler);
+            return () => mediaQuery.removeListener(handler);
+        };
+
+        const handleBreakpointChange = () => {
+            scheduleLayoutUpdate();
+        };
+
+        cleanupCallbacks.push(registerMediaListener(desktopQuery, handleBreakpointChange));
+        cleanupCallbacks.push(registerMediaListener(tabletQuery, handleBreakpointChange));
+
         const nextSlide = () => {
-            const maxIndex = 3;
+            const maxIndex = getMaxIndex();
             currentIndex = currentIndex >= maxIndex ? 0 : currentIndex + 1;
             showSlide(currentIndex);
         };
-        
+
         const prevSlide = () => {
-            const maxIndex = 3;
+            const maxIndex = getMaxIndex();
             currentIndex = currentIndex <= 0 ? maxIndex : currentIndex - 1;
             showSlide(currentIndex);
         };
 
         const startAutoSlide = () => {
+            if (intervalId || !isSliderVisible) return;
             intervalId = setInterval(nextSlide, 7000);
         };
 
         const stopAutoSlide = () => {
+            if (!intervalId) return;
             clearInterval(intervalId);
+            intervalId = null;
         };
 
         nextButton.addEventListener('click', () => {
@@ -119,14 +197,49 @@ document.addEventListener('DOMContentLoaded', function() {
             startAutoSlide();
         });
 
-        // RESIZE LISTENER PASIVO
-        window.addEventListener('resize', () => {
-            updateSlidesPerView();
-            showSlide(currentIndex);
-        }, { passive: true });
-        
-        updateSlidesPerView();
-        startAutoSlide();
+        if ('IntersectionObserver' in window) {
+            sliderObserver = new IntersectionObserver((entries) => {
+                entries.forEach(entry => {
+                    if (entry.target !== slider) return;
+                    isSliderVisible = entry.isIntersecting;
+
+                    if (isSliderVisible) {
+                        startAutoSlide();
+                    } else {
+                        stopAutoSlide();
+                    }
+                });
+            }, { threshold: 0.2 });
+
+            sliderObserver.observe(slider);
+            cleanupCallbacks.push(() => sliderObserver && sliderObserver.disconnect());
+        } else {
+            startAutoSlide();
+        }
+
+        applySliderLayout();
+        if (!intervalId && isSliderVisible) {
+            startAutoSlide();
+        }
+
+        const cleanup = () => {
+            stopAutoSlide();
+            if (layoutUpdateTimeoutId) {
+                clearTimeout(layoutUpdateTimeoutId);
+                layoutUpdateTimeoutId = null;
+            }
+            cleanupCallbacks.forEach(fn => {
+                if (typeof fn === 'function') {
+                    fn();
+                }
+            });
+            cleanupCallbacks.length = 0;
+            window.removeEventListener('pagehide', cleanup);
+            window.removeEventListener('beforeunload', cleanup);
+        };
+
+        window.addEventListener('pagehide', cleanup, { once: true });
+        window.addEventListener('beforeunload', cleanup, { once: true });
     }
 
     // GOOGLE MAPS LAZY LOAD AUTOMÁTICO CON INTERSECTION OBSERVER


### PR DESCRIPTION
## Summary
- debounce the testimonial carousel layout adjustments and reuse pagination dots when the column count stays stable
- replace per-pixel resize logic with matchMedia breakpoints so slides per view only updates at width thresholds
- pause auto-rotation while the carousel is off-screen and tear down observers/listeners when the page unloads

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1b53863c88325af3283ed542717df