### PR TITLE
Remove unused CDNJS preconnect links

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
     <!-- OPTIMIZACIÓN: Preconnect a dominios externos -->
-    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
     <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
     <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
     

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
     <!-- OPTIMIZACIÓN: Preconnect a dominios externos -->
-    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
     <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
     <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
 

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
     <!-- OPTIMIZACIÓN: Preconnect a dominios externos -->
-    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
     <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
     <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
     <meta charset="UTF-8">


### PR DESCRIPTION
## Summary
- remove the unused cdnjs preconnect hint from the main and therapy pages
- confirm no other references to cdnjs remain in the project

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1b74cc9e48325b5a21ad1de960d84