### PR TITLE
SEO/A11y — Encabezados secuenciales + enlaces descriptivos

### DIFF
--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -134,7 +134,7 @@
                 <li>Los daños o perjuicios causados por el acceso o uso del sitio web</li>
             </ul>
 
-            <h3>Enlaces a Terceros</h3>
+            <h3 class="legal-subheading">Enlaces a Terceros</h3>
             <p>Este sitio web puede contener enlaces a páginas web de terceros. Teniendo en cuenta la imposibilidad de control respecto a la información, contenidos y servicios que contengan esas páginas web externas, quedamos eximidos de cualquier responsabilidad por los daños y perjuicios de toda clase que pudiesen derivar de su utilización.</p>
             
             <p>La inclusión de enlaces no implica aprobación ni recomendación de los contenidos enlazados por parte del titular del sitio web.</p>
@@ -154,7 +154,7 @@
     <footer class="footer">
         <div class="container footer-grid">
             <div class="footer-col">
-                <h4>Javi Cáceres Psicólogo</h4>
+                <h3 class="footer-heading">Javi Cáceres Psicólogo</h3>
                 <p>Psicólogo Sanitario en Roses (Girona) y Online. Col. 16.772.</p>
                 <img src="images/colegio-psicologos.webp" 
                     alt="Logo del Col·legi Oficial de Psicologia de Catalunya"
@@ -163,7 +163,7 @@
                     style="max-width: 200px; height: auto; margin-top: 1rem; border-radius: 8px;">
             </div>
             <div class="footer-col">
-                <h4>Servicios</h4>
+                <h3 class="footer-heading">Servicios</h3>
                 <ul>
                     <li><a href="index.html">Terapia Presencial (Roses)</a></li>
                     <li><a href="terapia-online.html">Terapia Breve Online</a></li>
@@ -171,7 +171,7 @@
                 </ul>
             </div>
             <div class="footer-col">
-                <h4>Contacto</h4>
+                <h3 class="footer-heading">Contacto</h3>
                 <ul>
                     <li><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z" fill="currentColor" /></svg></span>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
                     <li><a href="tel:+34621372442"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Teléfono" focusable="false"><path d="M224.2 89C216.3 70.1 195.7 60.1 176.1 65.4L170.6 66.9C106 84.5 50.8 147.1 66.9 223.3C104 398.3 241.7 536 416.7 573.1C493 589.3 555.5 534 573.1 469.4L574.6 463.9C580 444.2 569.9 423.6 551.1 415.8L453.8 375.3C437.3 368.4 418.2 373.2 406.8 387.1L368.2 434.3C297.9 399.4 241.3 341 208.8 269.3L253 233.3C266.9 222 271.6 202.9 264.8 186.3L224.2 89z" fill="currentColor" /></svg></span>621 372 442</a></li>
@@ -179,7 +179,7 @@
                 </ul>
             </div>
             <div class="footer-col">
-                <h4>Legal</h4>
+                <h3 class="footer-heading">Legal</h3>
                 <ul>
                     <li><a href="politica-privacidad.html">Privacidad</a></li>
                     <li><a href="aviso-legal.html">Aviso Legal</a></li>
@@ -192,7 +192,7 @@
     </footer>
 
     <div class="cookie-consent-banner" id="cookie-banner" role="dialog" aria-modal="true" aria-hidden="true">
-        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información</a>.</p>
+        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información sobre cookies</a>.</p>
         <div class="cookie-consent-banner__actions">
             <button class="btn btn-secondary" id="reject-cookies-btn" type="button">Rechazar</button>
             <button class="btn btn-primary" id="accept-cookies-btn" type="button">Aceptar</button>

--- a/codigo-deontologico.html
+++ b/codigo-deontologico.html
@@ -99,7 +99,7 @@
             </p>
             
             <div class="highlight-box">
-                <h3>Principios Generales Clave</h3>
+                <h2 class="highlight-heading">Principios Generales Clave</h2>
                 <p>En el ejercicio de la profesión, como psicólogo, estoy obligado a respetar los principios comunes a toda deontología profesional (basado en el Artículo 5 del Codi Deontològic del COPC):</p>
                 <ul>
                     <li><strong>El respeto a la persona,</strong> reconociendo su dignidad y valor inherente.</li>
@@ -112,7 +112,7 @@
                 </ul>
                 <p style="margin-top: 1.5rem;">Además, la práctica psicológica se enmarca en los principios de <strong>beneficencia y no-maleficencia</strong>, lo que significa un compromiso permanente con la promoción del bienestar y la evitación de cualquier daño.</p>
 
-                <h3>Confidencialidad</h3>
+                <h2 class="highlight-heading">Confidencialidad</h2>
                 <p>La información que recojo en el ejercicio de mi profesión está sometida a un estricto deber de <strong>confidencialidad profesional</strong> (basado en el Artículo 38 del Codi Deontològic del COPC).</p>
                 <ul>
                     <li>Solo se puede eximir de esta confidencialidad con el <strong>consentimiento expreso e informado del usuario</strong> o en los supuestos contemplados por la <strong>legislación vigente</strong>.</li>
@@ -121,7 +121,7 @@
                     <li>Toda la información compartida en las sesiones está protegida por el secreto profesional y no será revelada sin autorización expresa, salvo en las excepciones legales mencionadas.</li>
                 </ul>
 
-                <h3>Consentimiento Informado</h3>
+                <h2 class="highlight-heading">Consentimiento Informado</h2>
                 <p>Antes de iniciar cualquier intervención psicológica, proporciono información completa y comprensible sobre:</p>
                 <ul>
                     <li>La naturaleza y objetivos del tratamiento propuesto</li>
@@ -142,7 +142,7 @@
     <footer class="footer">
         <div class="container footer-grid">
             <div class="footer-col">
-                <h4>Javi Cáceres Psicólogo</h4>
+                <h3 class="footer-heading">Javi Cáceres Psicólogo</h3>
                 <p>Psicólogo Sanitario en Roses (Girona) y Online. Col. 16.772.</p>
                 <img src="images/colegio-psicologos.webp" 
                     alt="Logo del Col·legi Oficial de Psicologia de Catalunya"
@@ -151,7 +151,7 @@
                     style="max-width: 200px; height: auto; margin-top: 1rem; border-radius: 8px;">
             </div>
             <div class="footer-col">
-                <h4>Servicios</h4>
+                <h3 class="footer-heading">Servicios</h3>
                 <ul>
                     <li><a href="index.html">Terapia Presencial (Roses)</a></li>
                     <li><a href="terapia-online.html">Terapia Breve Online</a></li>
@@ -159,7 +159,7 @@
                 </ul>
             </div>
             <div class="footer-col">
-                <h4>Contacto</h4>
+                <h3 class="footer-heading">Contacto</h3>
                 <ul>
                     <li><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z" fill="currentColor" /></svg></span>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
                     <li><a href="tel:+34621372442"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Teléfono" focusable="false"><path d="M224.2 89C216.3 70.1 195.7 60.1 176.1 65.4L170.6 66.9C106 84.5 50.8 147.1 66.9 223.3C104 398.3 241.7 536 416.7 573.1C493 589.3 555.5 534 573.1 469.4L574.6 463.9C580 444.2 569.9 423.6 551.1 415.8L453.8 375.3C437.3 368.4 418.2 373.2 406.8 387.1L368.2 434.3C297.9 399.4 241.3 341 208.8 269.3L253 233.3C266.9 222 271.6 202.9 264.8 186.3L224.2 89z" fill="currentColor" /></svg></span>621 372 442</a></li>
@@ -167,7 +167,7 @@
                 </ul>
             </div>
             <div class="footer-col">
-                <h4>Legal</h4>
+                <h3 class="footer-heading">Legal</h3>
                 <ul>
                     <li><a href="politica-privacidad.html">Privacidad</a></li>
                     <li><a href="aviso-legal.html">Aviso Legal</a></li>
@@ -180,7 +180,7 @@
     </footer>
 
     <div class="cookie-consent-banner" id="cookie-banner" role="dialog" aria-modal="true" aria-hidden="true">
-        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información</a>.</p>
+        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información sobre cookies</a>.</p>
         <div class="cookie-consent-banner__actions">
             <button class="btn btn-secondary" id="reject-cookies-btn" type="button">Rechazar</button>
             <button class="btn btn-primary" id="accept-cookies-btn" type="button">Aceptar</button>

--- a/css/base.css
+++ b/css/base.css
@@ -309,8 +309,10 @@ img {
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.footer-col h4 {
+.footer-heading {
     margin-bottom: 1rem;
+    font-size: 1.1rem;
+    font-weight: 600;
 }
 
 .footer-col p,

--- a/css/legal-styles.css
+++ b/css/legal-styles.css
@@ -23,7 +23,7 @@
     margin-top: 3rem;
 }
 
-.legal-content h3 {
+.legal-subheading {
     color: var(--accent-empathy);
     margin-top: 2rem;
 }
@@ -59,15 +59,27 @@
     box-shadow: var(--shadow-sm);
 }
 
-.highlight-box h3 {
+.highlight-heading {
     color: var(--accent-empathy);
     margin-top: 0;
+    border-bottom: none;
+    padding-bottom: 0;
+    margin-bottom: 1.5rem;
 }
 
-.highlight-box h3:not(:first-child) {
+.highlight-heading + .highlight-heading {
     margin-top: 2.5rem;
     padding-top: 2rem;
     border-top: 1px solid var(--bg-subtle);
+}
+
+.legal-section-heading {
+    color: var(--accent-empathy);
+    margin-top: 2.5rem;
+    margin-bottom: 1.25rem;
+    border-bottom: none;
+    padding-bottom: 0;
+    font-size: clamp(1.6rem, 3.5vw, 2.1rem);
 }
 
 @media (max-width: 768px) {

--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
                 <li><a href="#como-trabajo">Mi Enfoque</a></li>
                 <li><a href="#quien-soy">Sobre Mí</a></li>
                 <li><a href="#tarifas">Tarifas</a></li>
-                <li><a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información." target="_blank" class="btn btn-primary">Pedir Cita</a></li>
+                <li><a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información." target="_blank" rel="noopener" class="btn btn-primary">Pedir Cita</a></li>
             </ul>
             <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
@@ -194,7 +194,7 @@
                 <h1>¿La ansiedad o la tristeza te están alejando de la vida que deseas?</h1>
                 <p class="subtitle">No tienes por qué seguir así. Te ofrezco una terapia breve y colaborativa, un espacio de confianza donde, juntos, encontraremos tus recursos para que recuperes la calma, la claridad y el control.</p>
                 <div class="hero-actions">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20para%20una%20cita%20presencial." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Contactar por WhatsApp</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20para%20una%20cita%20presencial." target="_blank" rel="noopener" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Contactar por WhatsApp</a>
                     <a href="#tarifas" class="btn btn-secondary">Ver Tarifas</a>
                 </div>
             </div>
@@ -338,7 +338,7 @@
   <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
 </svg></span> Atención cercana y personalizada.</li>
                         </ul>
-                        <a href="https://wa.me/34621372442?text=Hola%20Javi,%20quiero%20pedir%20cita%20para%20una%20sesión%20presencial." target="_blank" class="btn btn-primary">Pedir Cita Presencial</a>
+                        <a href="https://wa.me/34621372442?text=Hola%20Javi,%20quiero%20pedir%20cita%20para%20una%20sesión%20presencial." target="_blank" rel="noopener" class="btn btn-primary">Pedir Cita Presencial</a>
                     </div>
                     <div class="tarifa-card">
                         <h3>Sesión de Pareja</h3>
@@ -452,8 +452,8 @@
                     <p><strong>Coordenadas GPS:</strong> 42.2642011, 3.1789986</p>
                     <div class="hero-actions" style="margin-top: 2rem; justify-content: flex-start; gap: 0.75rem;">
                         <a href="https://maps.app.goo.gl/qK8TCrotW8m6P8oCA" target="_blank" rel="noopener" class="btn btn-primary">Google Maps</a>
-                        <a href="https://maps.apple.com/?q=42.2642011,3.1789986" target="_blank" class="btn btn-secondary">Apple Maps</a>
-                        <a href="https://ul.waze.com/ul?ll=42.2642011,3.1789986&navigate=yes" target="_blank" class="btn btn-secondary">Waze</a>
+                        <a href="https://maps.apple.com/?q=42.2642011,3.1789986" target="_blank" rel="noopener" class="btn btn-secondary">Apple Maps</a>
+                        <a href="https://ul.waze.com/ul?ll=42.2642011,3.1789986&navigate=yes" target="_blank" rel="noopener" class="btn btn-secondary">Waze</a>
                     </div>
                 </div>
                 <div>
@@ -520,7 +520,7 @@
                 <h2>El cambio empieza con una conversación. ¿Hablamos?</h2>
                 <p>Dar el primer paso es el más valiente. Escríbeme sin compromiso para resolver cualquier duda o para concertar una primera cita. Estoy aquí para escucharte.</p>
                 <div class="hero-actions" style="margin-top: 2rem;">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20para%20una%20cita." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Escríbeme por WhatsApp</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20para%20una%20cita." target="_blank" rel="noopener" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Escríbeme por WhatsApp</a>
                 </div>
             </div>
         </section>
@@ -529,9 +529,9 @@
     <footer class="footer">
         <div class="container footer-grid">
             <div class="footer-col">
-                <h4>Javi Cáceres Psicólogo</h4>
+                <h3 class="footer-heading">Javi Cáceres Psicólogo</h3>
                 <p>Psicólogo Sanitario en Roses (Girona) y Online. Col. 16.772.</p>
-                <img src="images/colegio-psicologos.webp" 
+                <img src="images/colegio-psicologos.webp"
                     alt="Logo del Col·legi Oficial de Psicologia de Catalunya"
                     width="500"
                     height="224"
@@ -539,7 +539,7 @@
                     style="max-width: 200px; height: auto; margin-top: 1rem; border-radius: 8px;">
             </div>
             <div class="footer-col">
-                <h4>Servicios</h4>
+                <h3 class="footer-heading">Servicios</h3>
                 <ul>
                     <li><a href="index.html">Terapia Presencial (Roses)</a></li>
                     <li><a href="terapia-online.html">Terapia Breve Online</a></li>
@@ -547,7 +547,7 @@
                 </ul>
             </div>
             <div class="footer-col">
-                <h4>Contacto</h4>
+                <h3 class="footer-heading">Contacto</h3>
                 <ul>
                     <li>
                         <span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z" fill="currentColor" /></svg></span>
@@ -560,7 +560,7 @@
                 </ul>
             </div>
             <div class="footer-col">
-                <h4>Legal</h4>
+                <h3 class="footer-heading">Legal</h3>
                 <ul>
                     <li><a href="politica-privacidad.html">Privacidad</a></li>
                     <li><a href="aviso-legal.html">Aviso Legal</a></li>
@@ -572,10 +572,10 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
 
-    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"></a>
+    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información." class="whatsapp-float" target="_blank" rel="noopener" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"></a>
 
     <div class="cookie-consent-banner" id="cookie-banner" role="dialog" aria-modal="true" aria-hidden="true">
-        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información</a>.</p>
+        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información sobre cookies</a>.</p>
         <div class="cookie-consent-banner__actions">
             <button class="btn btn-secondary" id="reject-cookies-btn" type="button">Rechazar</button>
             <button class="btn btn-primary" id="accept-cookies-btn" type="button">Aceptar</button>

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -86,10 +86,10 @@
             <p>Nuestra página web utiliza cookies para analizar la navegación de usuarios y mejorar la experiencia de navegación.</p>
             <p>Las cookies son pequeños archivos que se instalan en el equipo desde el que accedes a nuestra web con las finalidades que se describen en esta página.</p>
             
-            <h3>¿Qué son las cookies?</h3>
+            <h2 class="legal-section-heading">¿Qué son las cookies?</h2>
             <p>Una cookie es un fichero que se descarga en tu ordenador al acceder a determinadas páginas web. Las cookies permiten a una página web, entre otras cosas, almacenar y recuperar información sobre los hábitos de navegación de un usuario o de su equipo y, dependiendo de la información que contengan y de la forma en que utilice su equipo, pueden utilizarse para reconocer al usuario.</p>
 
-            <h3>Información y Análisis de Navegación</h3>
+            <h2 class="legal-section-heading">Información y Análisis de Navegación</h2>
             <p>La aplicación que utilizamos para obtener y analizar la información de la navegación es: <strong>Google Analytics</strong>.</p>
             <p>Puedes encontrar más información en:</p>
             <ul>
@@ -99,7 +99,7 @@
             
             <p>Esta aplicación ha sido desarrollada por Google, que nos presta el servicio de análisis de la audiencia de nuestra página. Esta empresa puede utilizar estos datos para mejorar sus propios servicios y para ofrecer servicios a otras empresas.</p>
             
-            <h3>¿Qué información recopilan las cookies?</h3>
+            <h2 class="legal-section-heading">¿Qué información recopilan las cookies?</h2>
             <p>Esta herramienta no obtiene datos de los nombres o apellidos de los usuarios ni de la dirección postal desde donde se conectan. La información que obtiene está relacionada, por ejemplo, con:</p>
             <ul>
                 <li>Número de páginas visitadas</li>
@@ -114,7 +114,7 @@
             
             <p>Esta información la utilizamos para mejorar nuestra página, detectar nuevas necesidades y valorar las mejoras a introducir con la finalidad de prestar un mejor servicio a los usuarios que nos visitan.</p>
             
-            <h3>Gestión de Cookies en tu Navegador</h3>
+            <h2 class="legal-section-heading">Gestión de Cookies en tu Navegador</h2>
             <p>Para permitir, conocer, bloquear o eliminar las cookies instaladas en tu equipo puedes hacerlo mediante la configuración de las opciones del navegador instalado en tu ordenador.</p>
             <p>A continuación, te proporcionamos enlaces sobre cómo gestionar las cookies en los navegadores más comunes:</p>
             <ul>
@@ -134,7 +134,7 @@
     <footer class="footer">
         <div class="container footer-grid">
             <div class="footer-col">
-                <h4>Javi Cáceres Psicólogo</h4>
+                <h3 class="footer-heading">Javi Cáceres Psicólogo</h3>
                 <p>Psicólogo Sanitario en Roses (Girona) y Online. Col. 16.772.</p>
                 <img src="images/colegio-psicologos.webp" 
                     alt="Logo del Col·legi Oficial de Psicologia de Catalunya"
@@ -143,7 +143,7 @@
                     style="max-width: 200px; height: auto; margin-top: 1rem; border-radius: 8px;">
             </div>
             <div class="footer-col">
-                <h4>Servicios</h4>
+                <h3 class="footer-heading">Servicios</h3>
                 <ul>
                     <li><a href="index.html">Terapia Presencial (Roses)</a></li>
                     <li><a href="terapia-online.html">Terapia Breve Online</a></li>
@@ -151,7 +151,7 @@
                 </ul>
             </div>
             <div class="footer-col">
-                <h4>Contacto</h4>
+                <h3 class="footer-heading">Contacto</h3>
                 <ul>
                     <li><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z" fill="currentColor" /></svg></span>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
                     <li><a href="tel:+34621372442"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Teléfono" focusable="false"><path d="M224.2 89C216.3 70.1 195.7 60.1 176.1 65.4L170.6 66.9C106 84.5 50.8 147.1 66.9 223.3C104 398.3 241.7 536 416.7 573.1C493 589.3 555.5 534 573.1 469.4L574.6 463.9C580 444.2 569.9 423.6 551.1 415.8L453.8 375.3C437.3 368.4 418.2 373.2 406.8 387.1L368.2 434.3C297.9 399.4 241.3 341 208.8 269.3L253 233.3C266.9 222 271.6 202.9 264.8 186.3L224.2 89z" fill="currentColor" /></svg></span>621 372 442</a></li>
@@ -159,7 +159,7 @@
                 </ul>
             </div>
             <div class="footer-col">
-                <h4>Legal</h4>
+                <h3 class="footer-heading">Legal</h3>
                 <ul>
                     <li><a href="politica-privacidad.html">Privacidad</a></li>
                     <li><a href="aviso-legal.html">Aviso Legal</a></li>
@@ -172,7 +172,7 @@
     </footer>
     
     <div class="cookie-consent-banner" id="cookie-banner" role="dialog" aria-modal="true" aria-hidden="true">
-        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información</a>.</p>
+        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información sobre cookies</a>.</p>
         <div class="cookie-consent-banner__actions">
             <button class="btn btn-secondary" id="reject-cookies-btn" type="button">Rechazar</button>
             <button class="btn btn-primary" id="accept-cookies-btn" type="button">Aceptar</button>

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -96,12 +96,12 @@
 
             <h2>2. Finalidades, Legitimación y Conservación</h2>
             
-            <h3>Contacto a través de Email, Teléfono o WhatsApp</h3>
+            <h3 class="legal-subheading">Contacto a través de Email, Teléfono o WhatsApp</h3>
             <p><strong>Finalidad:</strong> Facilitarle un medio para que pueda ponerse en contacto conmigo y contestar a sus solicitudes de información y citas.</p>
             <p><strong>Legitimación:</strong> El consentimiento del usuario al solicitar información a través de los medios de contacto proporcionados.</p>
             <p><strong>Conservación:</strong> Una vez resuelta su solicitud, si no ha generado un nuevo tratamiento (inicio de terapia), los datos se eliminarán en un plazo prudencial.</p>
             
-            <h3>Obligación de facilitarnos sus datos personales y consecuencias de no hacerlo</h3>
+            <h3 class="legal-subheading">Obligación de facilitarnos sus datos personales y consecuencias de no hacerlo</h3>
             <p>El suministro de datos personales requiere una edad mínima de 18 años o, en su caso, disponer de capacidad jurídica suficiente para contratar.</p>
             <p>Los datos personales solicitados son necesarios para gestionar sus solicitudes. Si no nos los facilita, no podremos atenderle correctamente.</p>
 
@@ -136,7 +136,7 @@
     <footer class="footer">
         <div class="container footer-grid">
             <div class="footer-col">
-                <h4>Javi Cáceres Psicólogo</h4>
+                <h3 class="footer-heading">Javi Cáceres Psicólogo</h3>
                 <p>Psicólogo Sanitario en Roses (Girona) y Online. Col. 16.772.</p>
                 <img src="images/colegio-psicologos.webp" 
                     alt="Logo del Col·legi Oficial de Psicologia de Catalunya"
@@ -145,7 +145,7 @@
                     style="max-width: 200px; height: auto; margin-top: 1rem; border-radius: 8px;">
             </div>
             <div class="footer-col">
-                <h4>Servicios</h4>
+                <h3 class="footer-heading">Servicios</h3>
                 <ul>
                     <li><a href="index.html">Terapia Presencial (Roses)</a></li>
                     <li><a href="terapia-online.html">Terapia Breve Online</a></li>
@@ -153,7 +153,7 @@
                 </ul>
             </div>
             <div class="footer-col">
-                <h4>Contacto</h4>
+                <h3 class="footer-heading">Contacto</h3>
                 <ul>
                     <li><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z" fill="currentColor" /></svg></span>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
                     <li><a href="tel:+34621372442"><span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" style="margin-right: 0.5rem;" role="img" aria-label="Teléfono" focusable="false"><path d="M224.2 89C216.3 70.1 195.7 60.1 176.1 65.4L170.6 66.9C106 84.5 50.8 147.1 66.9 223.3C104 398.3 241.7 536 416.7 573.1C493 589.3 555.5 534 573.1 469.4L574.6 463.9C580 444.2 569.9 423.6 551.1 415.8L453.8 375.3C437.3 368.4 418.2 373.2 406.8 387.1L368.2 434.3C297.9 399.4 241.3 341 208.8 269.3L253 233.3C266.9 222 271.6 202.9 264.8 186.3L224.2 89z" fill="currentColor" /></svg></span>621 372 442</a></li>
@@ -161,7 +161,7 @@
                 </ul>
             </div>
             <div class="footer-col">
-                <h4>Legal</h4>
+                <h3 class="footer-heading">Legal</h3>
                 <ul>
                     <li><a href="politica-privacidad.html">Privacidad</a></li>
                     <li><a href="aviso-legal.html">Aviso Legal</a></li>
@@ -174,7 +174,7 @@
     </footer>
     
     <div class="cookie-consent-banner" id="cookie-banner" role="dialog" aria-modal="true" aria-hidden="true">
-        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información</a>.</p>
+        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información sobre cookies</a>.</p>
         <div class="cookie-consent-banner__actions">
             <button class="btn btn-secondary" id="reject-cookies-btn" type="button">Rechazar</button>
             <button class="btn btn-primary" id="accept-cookies-btn" type="button">Aceptar</button>

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -132,7 +132,7 @@
                 <li><a href="#como-funciona">Cómo Funciona</a></li>
                 <li><a href="#quien-soy">Sobre Mí</a></li>
                 <li><a href="#tarifas">Tarifas</a></li>
-                <li><a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" class="btn btn-primary">Pedir Cita</a></li>
+                <li><a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" rel="noopener" class="btn btn-primary">Pedir Cita</a></li>
             </ul>
             <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
@@ -162,7 +162,7 @@
                 <h1>¿La distancia o la falta de tiempo te impiden cuidar de tu bienestar?</h1>
                 <p class="subtitle">La terapia online te ofrece el mismo nivel de calidad y cercanía que la presencial, pero con la flexibilidad que necesitas. Desde tu casa, desde donde estés, cuando mejor te venga.</p>
                 <div class="hero-actions">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Empezar Ahora</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" rel="noopener" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Empezar Ahora</a>
                 </div>
             </div>
         </section>
@@ -359,7 +359,7 @@
   <path d="M438.6 105.4a24 24 0 0 1 0 33.9l-256 256a24 24 0 0 1-33.9 0l-139-139a24 24 0 1 1 33.9-33.9L168 328.4 404.7 105.4a24 24 0 0 1 33.9 0Z" fill="currentColor" />
 </svg></span> Pago seguro por Bizum o transferencia</li>
                     </ul>
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20cita%20para%20una%20sesión%20online." target="_blank" class="btn btn-primary">Reservar Sesión Online</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20cita%20para%20una%20sesión%20online." target="_blank" rel="noopener" class="btn btn-primary">Reservar Sesión Online</a>
                 </div>
             </div>
         </section>
@@ -412,7 +412,7 @@
                 <h2>Tu bienestar no puede esperar. Empieza hoy.</h2>
                 <p>No dejes que la falta de tiempo o la ubicación sean un obstáculo para sentirte mejor. La terapia breve online es una puerta abierta a tu cambio personal. ¿Hablamos?</p>
                 <div class="hero-actions" style="margin-top: 2rem;">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Empezar Terapia Online</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" rel="noopener" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Empezar Terapia Online</a>
                 </div>
             </div>
         </section>
@@ -421,7 +421,7 @@
     <footer class="footer">
         <div class="container footer-grid">
             <div class="footer-col">
-                <h4>Javi Cáceres Psicólogo</h4>
+                <h3 class="footer-heading">Javi Cáceres Psicólogo</h3>
                 <p>Psicólogo Sanitario en Roses (Girona) y Online. Col. 16.772.</p>
                 <img src="images/colegio-psicologos.webp" 
                     alt="Logo del Col·legi Oficial de Psicologia de Catalunya"
@@ -431,7 +431,7 @@
                     style="max-width: 200px; height: auto; margin-top: 1rem; border-radius: 8px;">
             </div>
             <div class="footer-col">
-                <h4>Servicios</h4>
+                <h3 class="footer-heading">Servicios</h3>
                 <ul>
                     <li><a href="index.html">Terapia Presencial (Roses)</a></li>
                     <li><a href="terapia-online.html">Terapia Breve Online</a></li>
@@ -439,7 +439,7 @@
                 </ul>
             </div>
             <div class="footer-col">
-                <h4>Contacto</h4>
+                <h3 class="footer-heading">Contacto</h3>
                 <ul>
                     <li>
                         <span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z" fill="currentColor" /></svg></span>
@@ -452,7 +452,7 @@
                 </ul>
             </div>
             <div class="footer-col">
-                <h4>Legal</h4>
+                <h3 class="footer-heading">Legal</h3>
                 <ul>
                     <li><a href="politica-privacidad.html">Privacidad</a></li>
                     <li><a href="aviso-legal.html">Aviso Legal</a></li>
@@ -464,10 +464,10 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
 
-    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"></a>
+    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." class="whatsapp-float" target="_blank" rel="noopener" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"></a>
 
     <div class="cookie-consent-banner" id="cookie-banner" role="dialog" aria-modal="true" aria-hidden="true">
-        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información</a>.</p>
+        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información sobre cookies</a>.</p>
         <div class="cookie-consent-banner__actions">
             <button class="btn btn-secondary" id="reject-cookies-btn" type="button">Rechazar</button>
             <button class="btn btn-primary" id="accept-cookies-btn" type="button">Aceptar</button>

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -140,7 +140,7 @@
                 <li><a href="#metodo">El Método</a></li>
                 <li><a href="#quien-soy">Sobre Mí</a></li>
                 <li><a href="#tarifas">Tarifas</a></li>
-                <li><a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" class="btn btn-primary">Pedir Cita</a></li>
+                <li><a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" rel="noopener" class="btn btn-primary">Pedir Cita</a></li>
             </ul>
             <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false">
@@ -170,7 +170,7 @@
                 <h1>¿Sentís que la distancia y las discusiones se han adueñado de vuestra relación?</h1>
                 <p class="subtitle">Recuperar la conexión, la amistad y la pasión es posible. Os ofrezco un método de terapia de pareja basado en la ciencia (Gottman) y en vuestras propias fortalezas para reconstruir el "nosotros" que un día fuisteis.</p>
                 <div class="hero-actions">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Iniciar el Cambio</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" rel="noopener" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Iniciar el Cambio</a>
                 </div>
             </div>
         </section>
@@ -316,7 +316,7 @@
                     <div class="price">70€</div>
                     <p class="duration">Hasta 90 minutos | Presencial u Online</p>
                     <p>Un espacio y tiempo extendido para que ambos tengáis voz, permitiendo profundizar de manera efectiva desde el primer encuentro.</p>
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20cita%20para%20terapia%20de%20pareja." target="_blank" class="btn btn-primary">Pedir Cita de Pareja</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20cita%20para%20terapia%20de%20pareja." target="_blank" rel="noopener" class="btn btn-primary">Pedir Cita de Pareja</a>
                 </div>
             </div>
         </section>
@@ -332,8 +332,8 @@
                     <p><strong>Coordenadas GPS:</strong> 42.2642011, 3.1789986</p>
                     <div class="hero-actions" style="margin-top: 2rem; justify-content: flex-start; gap: 0.75rem;">
                         <a href="https://maps.app.goo.gl/qK8TCrotW8m6P8oCA" target="_blank" rel="noopener" class="btn btn-primary">Google Maps</a>
-                        <a href="https://maps.apple.com/?q=42.2642011,3.1789986" target="_blank" class="btn btn-secondary">Apple Maps</a>
-                        <a href="https://ul.waze.com/ul?ll=42.2642011,3.1789986&navigate=yes" target="_blank" class="btn btn-secondary">Waze</a>
+                        <a href="https://maps.apple.com/?q=42.2642011,3.1789986" target="_blank" rel="noopener" class="btn btn-secondary">Apple Maps</a>
+                        <a href="https://ul.waze.com/ul?ll=42.2642011,3.1789986&navigate=yes" target="_blank" rel="noopener" class="btn btn-secondary">Waze</a>
                     </div>                </div>
                 <div>
                      <div class="map-lazy-container" 
@@ -393,7 +393,7 @@
                 <h2>Construid el futuro que deseáis, juntos.</h2>
                 <p>Dar el paso de pedir ayuda como pareja es un acto de valentía y un gran gesto de amor hacia la relación. Si estáis listos para empezar a cambiar las cosas, estoy aquí para guiaros.</p>
                 <div class="hero-actions" style="margin-top: 2rem;">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Contactar para Terapia de Pareja</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" rel="noopener" class="btn btn-primary"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"> Contactar para Terapia de Pareja</a>
                 </div>
             </div>
         </section>
@@ -402,7 +402,7 @@
     <footer class="footer">
         <div class="container footer-grid">
             <div class="footer-col">
-                <h4>Javi Cáceres Psicólogo</h4>
+                <h3 class="footer-heading">Javi Cáceres Psicólogo</h3>
                 <p>Psicólogo Sanitario en Roses (Girona) y Online. Col. 16.772.</p>
                 <img src="images/colegio-psicologos.webp" 
                     alt="Logo del Col·legi Oficial de Psicologia de Catalunya"
@@ -412,7 +412,7 @@
                     style="max-width: 200px; height: auto; margin-top: 1rem; border-radius: 8px;">
             </div>
             <div class="footer-col">
-                <h4>Servicios</h4>
+                <h3 class="footer-heading">Servicios</h3>
                 <ul>
                     <li><a href="index.html">Terapia Presencial (Roses)</a></li>
                     <li><a href="terapia-online.html">Terapia Breve Online</a></li>
@@ -420,7 +420,7 @@
                 </ul>
             </div>
             <div class="footer-col">
-                <h4>Contacto</h4>
+                <h3 class="footer-heading">Contacto</h3>
                 <ul>
                     <li>
                         <span class="text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" class="icon" style="margin-right: 0.5rem;" aria-hidden="true" focusable="false"><path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z" fill="currentColor" /></svg></span>
@@ -433,7 +433,7 @@
                 </ul>
             </div>
             <div class="footer-col">
-                <h4>Legal</h4>
+                <h3 class="footer-heading">Legal</h3>
                 <ul>
                     <li><a href="politica-privacidad.html">Privacidad</a></li>
                     <li><a href="aviso-legal.html">Aviso Legal</a></li>
@@ -445,10 +445,10 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
 
-    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"></a>
+    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." class="whatsapp-float" target="_blank" rel="noopener" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"></a>
 
     <div class="cookie-consent-banner" id="cookie-banner" role="dialog" aria-modal="true" aria-hidden="true">
-        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información</a>.</p>
+        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información sobre cookies</a>.</p>
         <div class="cookie-consent-banner__actions">
             <button class="btn btn-secondary" id="reject-cookies-btn" type="button">Rechazar</button>
             <button class="btn btn-primary" id="accept-cookies-btn" type="button">Aceptar</button>


### PR DESCRIPTION
## Summary
- Normalize heading levels across all public pages so each document has a single `<h1>` and sequential subheadings, introducing utility classes to preserve legal-page styling and footer appearance.
- Update repeated footer markup to reuse a shared `.footer-heading` style and adjust cookie banner copy to reference cookies explicitly on every page.
- Add `rel="noopener"` to every external link that opens in a new tab and ensure CTA copy uses descriptive link text.

## Testing
- Not run (static content updates)


------
https://chatgpt.com/codex/tasks/task_e_68e1c1e23e108325b557a387191b7e34