### PR TITLE
A11y — Dianas táctiles carrusel (48px)

### DIFF
--- a/css/testimonios.css
+++ b/css/testimonios.css
@@ -92,24 +92,38 @@
 }
 
 .pagination-dot {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background-color: transparent;
+    cursor: pointer;
+    border: none;
+    padding: 0;
+}
+
+.pagination-dot::after {
+    content: "";
+    display: block;
     width: 12px;
     height: 12px;
     border-radius: 50%;
     background-color: var(--text-medium);
     opacity: 0.4;
-    cursor: pointer;
+    transform: scale(1);
     transition: all 0.3s ease;
-    border: none;
-    padding: 0;
 }
 
-.pagination-dot.active {
+.pagination-dot.active::after {
     background-color: var(--accent-empathy);
     opacity: 1;
     transform: scale(1.3);
 }
 
-.pagination-dot:hover {
+.pagination-dot:hover::after {
     opacity: 0.7;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -74,7 +74,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
             const safeIndex = Math.min(Math.max(currentIndex, 0), dots.length - 1);
             dots.forEach((dot, index) => {
-                dot.classList[index === safeIndex ? 'add' : 'remove']('active');
+                const isActive = index === safeIndex;
+                dot.classList[isActive ? 'add' : 'remove']('active');
+                if (isActive) {
+                    dot.setAttribute('aria-current', 'page');
+                } else {
+                    dot.removeAttribute('aria-current');
+                }
             });
         };
 
@@ -83,9 +89,15 @@ document.addEventListener('DOMContentLoaded', function() {
         const showSlide = (index) => {
             const maxIndex = getMaxIndex();
             currentIndex = Math.min(Math.max(index, 0), maxIndex);
-            const slideWidth = 100 / slidesPerView;
+
+            if (!totalPages) {
+                updatePagination();
+                return;
+            }
+
+            const translatePercentage = (currentIndex * 100) / totalPages;
             // Usar transform con will-change para mejor performance
-            slider.style.transform = `translateX(${-currentIndex * slideWidth}%)`;
+            slider.style.transform = `translateX(-${translatePercentage}%)`;
             updatePagination();
         };
 


### PR DESCRIPTION
## Summary
- Amplify the testimonial carousel pagination buttons to provide a 48×48 px touch target while keeping the visual dot unchanged via a pseudo-element.
- Ensure the active pagination dot exposes `aria-current="page"` so assistive technologies can announce the current slide.
- Fix the testimonial slider translation so navigation reveals all six reviews across breakpoints.

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1c3fe6740832589332995791f47c6