### PR TITLE
Best-Practices — Deprecations + deps limpias

### DIFF
--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -199,6 +199,6 @@
         </div>
     </div>
 
-    <script src="js/main.js"></script>
+    <script src="js/main.js" defer></script>
 </body>
 </html>

--- a/codigo-deontologico.html
+++ b/codigo-deontologico.html
@@ -187,6 +187,6 @@
         </div>
     </div>
 
-    <script src="js/main.js"></script>
+    <script src="js/main.js" defer></script>
 </body>
 </html>

--- a/css/base.css
+++ b/css/base.css
@@ -57,6 +57,10 @@ h1 {
     font-size: clamp(2.4rem, 5vw, 3.2rem);
 }
 
+:where(section, article, aside, nav) h1 {
+    font-size: clamp(2.4rem, 5vw, 3.2rem);
+}
+
 h2 {
     font-size: clamp(2rem, 4vw, 2.8rem);
 }

--- a/index.html
+++ b/index.html
@@ -582,6 +582,6 @@
         </div>
     </div>
 
-    <script src="js/main.js"></script>
+    <script src="js/main.js" defer></script>
 </body>
 </html>

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -179,6 +179,6 @@
         </div>
     </div>
 
-    <script src="js/main.js"></script>
+    <script src="js/main.js" defer></script>
 </body>
 </html>

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -181,6 +181,6 @@
         </div>
     </div>
 
-    <script src="js/main.js"></script>
+    <script src="js/main.js" defer></script>
 </body>
 </html>

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -474,6 +474,6 @@
         </div>
     </div>
 
-    <script src="js/main.js"></script>
+    <script src="js/main.js" defer></script>
 </body>
 </html>

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -455,6 +455,6 @@
         </div>
     </div>
 
-    <script src="js/main.js"></script>
+    <script src="js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add an explicit font-size override for headings within semantic sections to avoid relying on deprecated UA defaults.
- Load the shared `main.js` bundle with `defer` on every page so the script no longer blocks parsing.

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e1c6098dd083258d7ec91946c56683