### PR TITLE
Cookies — Unificación, contraste AA y cierre con clic (todas las páginas)

### DIFF
--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -239,14 +239,16 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
 
-    <div class="cookie-consent-banner" id="cookie-banner" role="dialog" aria-modal="true" aria-hidden="true">
-        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información sobre cookies</a>.</p>
-        <div class="cookie-consent-banner__actions">
-            <button class="btn btn-secondary" id="reject-cookies-btn" type="button">Rechazar</button>
-            <button class="btn btn-primary" id="accept-cookies-btn" type="button">Aceptar</button>
+    <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
+        <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>
+        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información</a></p>
+        <div class="cookie-actions">
+            <button class="btn btn-secondary js-cookie-reject">Rechazar</button>
+            <button class="btn btn-primary js-cookie-accept">Aceptar</button>
         </div>
     </div>
 
-    <script src="js/main.js" defer></script>
+    <script src="/js/main.js" defer></script>
+    <script src="/js/cookies.js" defer></script>
 </body>
 </html>

--- a/codigo-deontologico.html
+++ b/codigo-deontologico.html
@@ -227,14 +227,16 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
 
-    <div class="cookie-consent-banner" id="cookie-banner" role="dialog" aria-modal="true" aria-hidden="true">
-        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información sobre cookies</a>.</p>
-        <div class="cookie-consent-banner__actions">
-            <button class="btn btn-secondary" id="reject-cookies-btn" type="button">Rechazar</button>
-            <button class="btn btn-primary" id="accept-cookies-btn" type="button">Aceptar</button>
+    <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
+        <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>
+        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información</a></p>
+        <div class="cookie-actions">
+            <button class="btn btn-secondary js-cookie-reject">Rechazar</button>
+            <button class="btn btn-primary js-cookie-accept">Aceptar</button>
         </div>
     </div>
 
-    <script src="js/main.js" defer></script>
+    <script src="/js/main.js" defer></script>
+    <script src="/js/cookies.js" defer></script>
 </body>
 </html>

--- a/css/common.css
+++ b/css/common.css
@@ -271,49 +271,81 @@ section#especializacion .grid-2 > a {
     box-shadow: var(--shadow-lg);
 }
 
-.cookie-consent-banner {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(45, 55, 72, 0.95);
-    color: var(--white);
-    padding: 1.5rem;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 1rem;
-    z-index: 99999;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.4s ease-in-out;
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    border: 0;
+    white-space: nowrap;
 }
 
-.cookie-consent-banner.active {
+.cookie-banner {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 99999;
+    padding: 16px;
+    gap: 12px;
+    background: rgba(0, 0, 0, 0.88);
+    color: #fff;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    transform: translateY(100%);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.cookie-banner.is-visible {
+    transform: translateY(0);
     opacity: 1;
+    visibility: visible;
     pointer-events: auto;
 }
 
-.cookie-consent-banner p {
+.cookie-banner p,
+.cookie-banner a {
+    color: #fff;
+}
+
+.cookie-banner p {
     margin: 0;
-    font-size: 0.95rem;
 }
 
-.cookie-consent-banner a {
-    color: var(--bg-subtle);
+.cookie-link {
+    color: #fff;
     text-decoration: underline;
+    text-underline-offset: 2px;
 }
 
-.cookie-consent-banner__actions {
+.cookie-actions {
     display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    justify-content: center;
+    gap: 12px;
 }
 
-.cookie-consent-banner button {
-    min-width: 120px;
+.cookie-actions .btn {
+    outline-offset: 2px;
+}
+
+.cookie-actions .btn:focus {
+    outline: 2px solid #fff;
+}
+
+@media (max-width: 480px) {
+    .cookie-actions {
+        width: 100%;
+        justify-content: flex-end;
+    }
 }
 
 @media (min-width: 768px) {

--- a/index.html
+++ b/index.html
@@ -648,14 +648,16 @@
 
     <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información." class="whatsapp-float" target="_blank" rel="noopener" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"></a>
 
-    <div class="cookie-consent-banner" id="cookie-banner" role="dialog" aria-modal="true" aria-hidden="true">
-        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información sobre cookies</a>.</p>
-        <div class="cookie-consent-banner__actions">
-            <button class="btn btn-secondary" id="reject-cookies-btn" type="button">Rechazar</button>
-            <button class="btn btn-primary" id="accept-cookies-btn" type="button">Aceptar</button>
+    <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
+        <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>
+        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información</a></p>
+        <div class="cookie-actions">
+            <button class="btn btn-secondary js-cookie-reject">Rechazar</button>
+            <button class="btn btn-primary js-cookie-accept">Aceptar</button>
         </div>
     </div>
 
-    <script src="js/main.js" defer></script>
+    <script src="/js/main.js" defer></script>
+    <script src="/js/cookies.js" defer></script>
 </body>
 </html>

--- a/js/cookies.js
+++ b/js/cookies.js
@@ -1,0 +1,74 @@
+(function () {
+    const STORAGE_KEY = 'cookies-consent';
+
+    const getStoredConsent = () => {
+        try {
+            return window.localStorage.getItem(STORAGE_KEY);
+        } catch (error) {
+            return null;
+        }
+    };
+
+    const setStoredConsent = (value) => {
+        try {
+            window.localStorage.setItem(STORAGE_KEY, value);
+        } catch (error) {
+            // Ignore storage errors (private mode, etc.)
+        }
+    };
+
+    const callLoadGTM = () => {
+        if (typeof window.loadGTM === 'function') {
+            window.loadGTM();
+        }
+    };
+
+    const hideBanner = (banner) => {
+        banner.classList.remove('is-visible');
+        banner.setAttribute('aria-hidden', 'true');
+        banner.style.display = 'none';
+    };
+
+    const showBanner = (banner, acceptButton) => {
+        banner.style.display = 'flex';
+        requestAnimationFrame(() => {
+            banner.classList.add('is-visible');
+            banner.setAttribute('aria-hidden', 'false');
+            acceptButton?.focus({ preventScroll: true });
+        });
+    };
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const banner = document.querySelector('.cookie-banner');
+        if (!banner) {
+            return;
+        }
+
+        const acceptButton = banner.querySelector('.js-cookie-accept');
+        const rejectButton = banner.querySelector('.js-cookie-reject');
+
+        hideBanner(banner);
+
+        const storedConsent = getStoredConsent();
+
+        if (storedConsent === 'accepted') {
+            callLoadGTM();
+            return;
+        }
+
+        if (storedConsent !== 'rejected') {
+            showBanner(banner, acceptButton);
+        }
+
+        acceptButton?.addEventListener('click', () => {
+            setStoredConsent('accepted');
+            hideBanner(banner);
+            callLoadGTM();
+        });
+
+        rejectButton?.addEventListener('click', () => {
+            setStoredConsent('rejected');
+            hideBanner(banner);
+        });
+    });
+})();

--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,26 @@
 window.dataLayer = window.dataLayer || [];
 window.gtag = window.gtag || function gtag(){ window.dataLayer.push(arguments); };
 
+const GTAG_MEASUREMENT_ID = 'G-D5Z9J5PQCK';
+let gtmLoaded = false;
+
+function loadGTM() {
+    if (gtmLoaded) {
+        return;
+    }
+
+    gtmLoaded = true;
+    window.gtag('js', new Date());
+    window.gtag('config', GTAG_MEASUREMENT_ID);
+
+    const gtmScript = document.createElement('script');
+    gtmScript.defer = true;
+    gtmScript.src = `https://www.googletagmanager.com/gtag/js?id=${GTAG_MEASUREMENT_ID}`;
+    document.head.appendChild(gtmScript);
+}
+
+window.loadGTM = loadGTM;
+
 function setUniformTestimonialHeights(){
     const container = document.querySelector('.testimonials-section');
     if (!container) return;
@@ -335,162 +355,6 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         }
     };
-
-    // COOKIE CONSENT BANNER
-    const GTAG_MEASUREMENT_ID = 'G-D5Z9J5PQCK';
-    const CONSENT_STORAGE_KEY = 'cookieConsent';
-    const CONSENT_COOKIE_KEY = 'cookie_consent';
-    const CONSENT_COOKIE_MAX_AGE = 15552000; // 180 días en segundos
-    let gtmLoaded = false;
-
-    const cookieBanner = document.getElementById('cookie-banner');
-    const acceptCookiesBtn = document.getElementById('accept-cookies-btn');
-    const rejectCookiesBtn = document.getElementById('reject-cookies-btn');
-
-    const isLocalStorageAvailable = (() => {
-        try {
-            const testKey = '__consent_test__';
-            window.localStorage.setItem(testKey, '1');
-            window.localStorage.removeItem(testKey);
-            return true;
-        } catch (error) {
-            return false;
-        }
-    })();
-
-    const setCookieValue = (name, value, maxAgeSeconds) => {
-        document.cookie = `${name}=${value}; max-age=${maxAgeSeconds}; path=/`;
-    };
-
-    const getCookieValue = (name) => {
-        const nameEQ = `${name}=`;
-        return document.cookie
-            .split(';')
-            .map(cookie => cookie.trim())
-            .find(cookie => cookie.startsWith(nameEQ))?.substring(nameEQ.length) || null;
-    };
-
-    const getStoredConsent = () => {
-        let storedValue = null;
-
-        if (isLocalStorageAvailable) {
-            try {
-                storedValue = window.localStorage.getItem(CONSENT_STORAGE_KEY);
-            } catch (error) {
-                storedValue = null;
-            }
-        }
-
-        if (!storedValue) {
-            storedValue = getCookieValue(CONSENT_COOKIE_KEY);
-        }
-
-        return storedValue;
-    };
-
-    const persistConsent = (value) => {
-        let stored = false;
-
-        if (isLocalStorageAvailable) {
-            try {
-                window.localStorage.setItem(CONSENT_STORAGE_KEY, value);
-                stored = true;
-            } catch (error) {
-                stored = false;
-            }
-        }
-
-        if (!stored) {
-            try {
-                setCookieValue(CONSENT_COOKIE_KEY, value, CONSENT_COOKIE_MAX_AGE);
-                stored = true;
-            } catch (error) {
-                stored = false;
-            }
-        }
-
-        return stored;
-    };
-
-    const loadGTM = () => {
-        if (gtmLoaded) {
-            return;
-        }
-
-        gtmLoaded = true;
-        window.gtag('js', new Date());
-        window.gtag('config', GTAG_MEASUREMENT_ID);
-
-        const gtmScript = document.createElement('script');
-        gtmScript.defer = true;
-        gtmScript.src = `https://www.googletagmanager.com/gtag/js?id=${GTAG_MEASUREMENT_ID}`;
-        document.head.appendChild(gtmScript);
-    };
-
-    window.loadGTM = loadGTM;
-
-    const hideCookieBanner = () => {
-        if (!cookieBanner) {
-            return;
-        }
-
-        cookieBanner.classList.remove('active');
-        cookieBanner.setAttribute('aria-hidden', 'true');
-        document.removeEventListener('keydown', handleBannerKeydown);
-    };
-
-    const showCookieBanner = () => {
-        if (!cookieBanner) {
-            return;
-        }
-
-        cookieBanner.classList.add('active');
-        cookieBanner.setAttribute('aria-hidden', 'false');
-        document.addEventListener('keydown', handleBannerKeydown);
-
-        window.setTimeout(() => {
-            if (document.activeElement !== acceptCookiesBtn) {
-                acceptCookiesBtn?.focus({ preventScroll: true });
-            }
-        }, 0);
-    };
-
-    const handleBannerKeydown = (event) => {
-        if (event.key === 'Escape' || event.key === 'Esc') {
-            event.preventDefault();
-            if (rejectCookiesBtn) {
-                rejectCookiesBtn.click();
-            } else if (acceptCookiesBtn) {
-                acceptCookiesBtn.click();
-            }
-        }
-    };
-
-    if (cookieBanner && acceptCookiesBtn) {
-        const storedConsent = getStoredConsent();
-
-        if (storedConsent === 'accepted') {
-            loadGTM();
-            hideCookieBanner();
-        } else if (!storedConsent) {
-            showCookieBanner();
-        } else {
-            hideCookieBanner();
-        }
-
-        acceptCookiesBtn.addEventListener('click', () => {
-            persistConsent('accepted');
-            loadGTM();
-            hideCookieBanner();
-        });
-
-        if (rejectCookiesBtn) {
-            rejectCookiesBtn.addEventListener('click', () => {
-                persistConsent('rejected');
-                hideCookieBanner();
-            });
-        }
-    }
 
     // Inicializar lazy load de mapas
     initLazyMaps();

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -219,14 +219,16 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
     
-    <div class="cookie-consent-banner" id="cookie-banner" role="dialog" aria-modal="true" aria-hidden="true">
-        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información sobre cookies</a>.</p>
-        <div class="cookie-consent-banner__actions">
-            <button class="btn btn-secondary" id="reject-cookies-btn" type="button">Rechazar</button>
-            <button class="btn btn-primary" id="accept-cookies-btn" type="button">Aceptar</button>
+    <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
+        <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>
+        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información</a></p>
+        <div class="cookie-actions">
+            <button class="btn btn-secondary js-cookie-reject">Rechazar</button>
+            <button class="btn btn-primary js-cookie-accept">Aceptar</button>
         </div>
     </div>
 
-    <script src="js/main.js" defer></script>
+    <script src="/js/main.js" defer></script>
+    <script src="/js/cookies.js" defer></script>
 </body>
 </html>

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -221,14 +221,16 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
     
-    <div class="cookie-consent-banner" id="cookie-banner" role="dialog" aria-modal="true" aria-hidden="true">
-        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información sobre cookies</a>.</p>
-        <div class="cookie-consent-banner__actions">
-            <button class="btn btn-secondary" id="reject-cookies-btn" type="button">Rechazar</button>
-            <button class="btn btn-primary" id="accept-cookies-btn" type="button">Aceptar</button>
+    <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
+        <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>
+        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información</a></p>
+        <div class="cookie-actions">
+            <button class="btn btn-secondary js-cookie-reject">Rechazar</button>
+            <button class="btn btn-primary js-cookie-accept">Aceptar</button>
         </div>
     </div>
 
-    <script src="js/main.js" defer></script>
+    <script src="/js/main.js" defer></script>
+    <script src="/js/cookies.js" defer></script>
 </body>
 </html>

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -574,14 +574,16 @@
 
     <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." class="whatsapp-float" target="_blank" rel="noopener" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"></a>
 
-    <div class="cookie-consent-banner" id="cookie-banner" role="dialog" aria-modal="true" aria-hidden="true">
-        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información sobre cookies</a>.</p>
-        <div class="cookie-consent-banner__actions">
-            <button class="btn btn-secondary" id="reject-cookies-btn" type="button">Rechazar</button>
-            <button class="btn btn-primary" id="accept-cookies-btn" type="button">Aceptar</button>
+    <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
+        <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>
+        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información</a></p>
+        <div class="cookie-actions">
+            <button class="btn btn-secondary js-cookie-reject">Rechazar</button>
+            <button class="btn btn-primary js-cookie-accept">Aceptar</button>
         </div>
     </div>
 
-    <script src="js/main.js" defer></script>
+    <script src="/js/main.js" defer></script>
+    <script src="/js/cookies.js" defer></script>
 </body>
 </html>

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -546,14 +546,16 @@
 
     <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." class="whatsapp-float" target="_blank" rel="noopener" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" width="24" height="24" decoding="async"></a>
 
-    <div class="cookie-consent-banner" id="cookie-banner" role="dialog" aria-modal="true" aria-hidden="true">
-        <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información sobre cookies</a>.</p>
-        <div class="cookie-consent-banner__actions">
-            <button class="btn btn-secondary" id="reject-cookies-btn" type="button">Rechazar</button>
-            <button class="btn btn-primary" id="accept-cookies-btn" type="button">Aceptar</button>
+    <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
+        <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>
+        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información</a></p>
+        <div class="cookie-actions">
+            <button class="btn btn-secondary js-cookie-reject">Rechazar</button>
+            <button class="btn btn-primary js-cookie-accept">Aceptar</button>
         </div>
     </div>
 
-    <script src="js/main.js" defer></script>
+    <script src="/js/main.js" defer></script>
+    <script src="/js/cookies.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Resumen
- Unifiqué el banner de cookies en todas las plantillas HTML con el nuevo marcado accesible y los botones estandarizados.
- Moví los estilos del componente a `css/common.css` con contraste AA, foco visible y soporte responsive.
- Reorganicé la carga de GTM y añadí `js/cookies.js` para persistir la preferencia en `localStorage` y cerrar solo tras pulsar Aceptar/Rechazar.

## Archivos
- aviso-legal.html
- codigo-deontologico.html
- css/common.css
- index.html
- js/cookies.js
- js/main.js
- politica-cookies.html
- politica-privacidad.html
- terapia-online.html
- terapia-pareja.html

## Verificación
- [ ] En modo incógnito abrir index y una página legal → el banner aparece con buen contraste.
- [ ] Pulsar Aceptar → el banner desaparece en ambas; recargar y se mantiene oculto.
- [ ] Borrar `localStorage` y repetir con Rechazar → oculto y GTM no se carga.
- [ ] Confirmar que no hay CLS al mostrar/ocultar.


------
https://chatgpt.com/codex/tasks/task_e_68e24c8f755083259af8672b6cab2369