### PR TITLE
SEO — Enlace descriptivo a política de cookies (todas las páginas)

### DIFF
--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -241,7 +241,7 @@
 
     <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
         <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>
-        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información</a></p>
+        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información sobre la política de cookies</a></p>
         <div class="cookie-actions">
             <button class="btn btn-secondary js-cookie-reject">Rechazar</button>
             <button class="btn btn-primary js-cookie-accept">Aceptar</button>

--- a/codigo-deontologico.html
+++ b/codigo-deontologico.html
@@ -229,7 +229,7 @@
 
     <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
         <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>
-        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información</a></p>
+        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información sobre la política de cookies</a></p>
         <div class="cookie-actions">
             <button class="btn btn-secondary js-cookie-reject">Rechazar</button>
             <button class="btn btn-primary js-cookie-accept">Aceptar</button>

--- a/css/base.css
+++ b/css/base.css
@@ -152,6 +152,10 @@ strong {
     color: #fff;
 }
 
+.cookie-banner a {
+    white-space: normal;
+}
+
 .cookie-banner p {
     margin: 0;
 }

--- a/index.html
+++ b/index.html
@@ -650,7 +650,7 @@
 
     <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
         <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>
-        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información</a></p>
+        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información sobre la política de cookies</a></p>
         <div class="cookie-actions">
             <button class="btn btn-secondary js-cookie-reject">Rechazar</button>
             <button class="btn btn-primary js-cookie-accept">Aceptar</button>

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -221,7 +221,7 @@
     
     <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
         <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>
-        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información</a></p>
+        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información sobre la política de cookies</a></p>
         <div class="cookie-actions">
             <button class="btn btn-secondary js-cookie-reject">Rechazar</button>
             <button class="btn btn-primary js-cookie-accept">Aceptar</button>

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -223,7 +223,7 @@
     
     <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
         <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>
-        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información</a></p>
+        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información sobre la política de cookies</a></p>
         <div class="cookie-actions">
             <button class="btn btn-secondary js-cookie-reject">Rechazar</button>
             <button class="btn btn-primary js-cookie-accept">Aceptar</button>

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -576,7 +576,7 @@
 
     <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
         <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>
-        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información</a></p>
+        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información sobre la política de cookies</a></p>
         <div class="cookie-actions">
             <button class="btn btn-secondary js-cookie-reject">Rechazar</button>
             <button class="btn btn-primary js-cookie-accept">Aceptar</button>

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -548,7 +548,7 @@
 
     <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
         <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>
-        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información</a></p>
+        <p id="cookie-desc">Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a class="cookie-link" href="/politica-cookies.html" rel="noopener">Más información sobre la política de cookies</a></p>
         <div class="cookie-actions">
             <button class="btn btn-secondary js-cookie-reject">Rechazar</button>
             <button class="btn btn-primary js-cookie-accept">Aceptar</button>


### PR DESCRIPTION
## Summary
- Actualiza el texto visible del enlace a la política de cookies en el banner de consentimiento para mejorar su descriptividad.
- Permite el salto de línea del enlace del banner en móviles al normalizar el white-space.

## Files Modified
- index.html
- terapia-online.html
- terapia-pareja.html
- aviso-legal.html
- politica-privacidad.html
- politica-cookies.html
- codigo-deontologico.html
- css/base.css

## Testing
- No se ejecutaron pruebas (cambios de contenido/estilos).

------
https://chatgpt.com/codex/tasks/task_e_68e29433d4d483259a17d500328ba066