### PR TITLE
Ensure consistent heading scale across site

### DIFF
--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -41,6 +41,7 @@
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
     }
     </style>
+    <link rel="stylesheet" href="css/base.css">
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
     <link rel="preload" href="css/legal-styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
@@ -131,7 +132,7 @@
         <div class="container">
             <h1>Aviso Legal</h1>
             
-            <h2>Datos Identificativos del Titular</h2>
+            <h2 class="legal-heading">Datos Identificativos del Titular</h2>
             <div class="owner-details">
                 <p><strong>Titular:</strong> Francisco Javier Cáceres Velasco</p>
                 <p><strong>NIF:</strong> 40.439.688F</p>
@@ -142,7 +143,7 @@
 
             <p>Este sitio web se rige por la normativa exclusivamente aplicable en España, quedando sometidos a ella tanto usuarios nacionales como extranjeros que utilicen esta página web.</p>
 
-            <h2>Condiciones Generales de Uso</h2>
+            <h2 class="legal-heading">Condiciones Generales de Uso</h2>
             
             <p>El acceso a nuestro sitio web por parte del USUARIO es gratuito y está condicionado a la previa lectura y aceptación íntegra, expresa y sin reservas de las presentes <strong>CONDICIONES GENERALES DE USO</strong> vigentes en el momento del acceso.</p>
             
@@ -150,7 +151,7 @@
             
             <p>Nos reservamos el derecho a modificar en cualquier momento la presentación y configuración de nuestro sitio web, ampliar o reducir servicios, e incluso suprimirlo de la Red, así como los servicios y contenidos prestados, todo ello de forma unilateral y sin previo aviso.</p>
             
-            <h2>Propiedad Intelectual e Industrial</h2>
+            <h2 class="legal-heading">Propiedad Intelectual e Industrial</h2>
             
             <p>Todos los contenidos de este sitio web, incluyendo textos, imágenes, marcas, logotipos, combinaciones de colores, estructura y diseño, selección de materiales utilizados, programas de ordenador necesarios para su funcionamiento, acceso y uso, están protegidos por derechos de Propiedad Intelectual e Industrial.</p>
             
@@ -166,13 +167,13 @@
             
             <p>Cualquier uso no autorizado de los contenidos constituirá una infracción de las leyes de propiedad intelectual e industrial vigentes.</p>
 
-            <h2>Condiciones de Acceso</h2>
+            <h2 class="legal-heading">Condiciones de Acceso</h2>
             
             <p>El acceso a nuestra página web es gratuito y no exige previa suscripción o registro para la navegación general. El envío de datos personales a través de formularios de contacto implica la aceptación expresa de nuestra <a href="politica-privacidad.html">Política de Privacidad</a>.</p>
             
             <p>El usuario debe acceder a nuestro sitio web conforme a la buena fe, las normas de orden público, las presentes Condiciones Generales de Uso y la legislación vigente. El acceso se realiza bajo la propia y exclusiva responsabilidad del usuario.</p>
 
-            <h2>Exclusión de Responsabilidad</h2>
+            <h2 class="legal-heading">Exclusión de Responsabilidad</h2>
             
             <p>El titular del sitio web no se hace responsable de:</p>
             <ul>
@@ -187,11 +188,11 @@
             
             <p>La inclusión de enlaces no implica aprobación ni recomendación de los contenidos enlazados por parte del titular del sitio web.</p>
 
-            <h2>Protección de Datos</h2>
+            <h2 class="legal-heading">Protección de Datos</h2>
             
             <p>El tratamiento de datos personales recabados a través de este sitio web se rige por lo establecido en nuestra <a href="politica-privacidad.html">Política de Privacidad</a>, que cumple con el Reglamento General de Protección de Datos (RGPD) y la legislación española vigente en materia de protección de datos.</p>
 
-            <h2>Legislación Aplicable y Jurisdicción</h2>
+            <h2 class="legal-heading">Legislación Aplicable y Jurisdicción</h2>
             
             <p>Las presentes Condiciones Generales se rigen por la legislación española. Para la resolución de cualquier controversia relacionada con el acceso o uso del sitio web, el titular y el usuario acuerdan someterse a los Juzgados y Tribunales del domicilio del titular.</p>
             

--- a/codigo-deontologico.html
+++ b/codigo-deontologico.html
@@ -42,6 +42,7 @@
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
     }
     </style>
+    <link rel="stylesheet" href="css/base.css">
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
     <link rel="preload" href="css/legal-styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">

--- a/css/base.css
+++ b/css/base.css
@@ -17,6 +17,12 @@
     --border-width: 1px;
     --border-accent: 2px;
     --radius: 12px;
+    --fs-h1: clamp(28px, 4.5vw, 40px);
+    --fs-h2: clamp(24px, 3.6vw, 32px);
+    --fs-h3: clamp(20px, 2.8vw, 26px);
+    --fs-h4: clamp(18px, 2.2vw, 22px);
+    --fs-h5: 16px;
+    --fs-h6: 14px;
 }
 
 * {
@@ -54,6 +60,66 @@ h4 {
 
 h3 {
     font-weight: 600;
+}
+
+h1 {
+    font-size: var(--fs-h1);
+    line-height: 1.2;
+}
+
+h2 {
+    font-size: var(--fs-h2);
+    line-height: 1.25;
+}
+
+h3 {
+    font-size: var(--fs-h3);
+    line-height: 1.3;
+}
+
+h4 {
+    font-size: var(--fs-h4);
+    line-height: 1.35;
+}
+
+h5 {
+    font-size: var(--fs-h5);
+    line-height: 1.4;
+}
+
+h6 {
+    font-size: var(--fs-h6);
+    line-height: 1.45;
+}
+
+section h1,
+article h1 {
+    font-size: var(--fs-h1);
+}
+
+section h2,
+article h2 {
+    font-size: var(--fs-h2);
+}
+
+section h3,
+article h3 {
+    font-size: var(--fs-h3);
+}
+
+section h4,
+article h4 {
+    font-size: var(--fs-h4);
+}
+
+section h5,
+article h5 {
+    font-size: var(--fs-h5);
+}
+
+section h6,
+article h6 {
+    font-size: var(--fs-h6);
 }
 
 p {
@@ -419,34 +485,3 @@ img {
     }
 }
 
-:root {
-    --fs-h1: clamp(36px, 4.8vw, 52px);
-    --fs-h2: clamp(30px, 4vw, 44px);
-    --fs-h3: clamp(20px, 3vw, 26px);
-    --fs-h4: clamp(18px, 2.4vw, 22px);
-}
-
-h1 {
-    font-size: var(--fs-h1);
-    line-height: 1.2;
-}
-
-h2 {
-    font-size: var(--fs-h2);
-    line-height: 1.25;
-}
-
-h3 {
-    font-size: var(--fs-h3);
-    line-height: 1.3;
-}
-
-h4 {
-    font-size: var(--fs-h4);
-    line-height: 1.35;
-}
-
-section h1,
-article h1 {
-    font-size: var(--fs-h1);
-}

--- a/css/home.css
+++ b/css/home.css
@@ -1,4 +1,3 @@
-@import url('./base.css');
 @import url('./common.css');
 @import url('./hero.css');
 @import url('./space.css');

--- a/css/legal-styles.css
+++ b/css/legal-styles.css
@@ -1,5 +1,3 @@
-@import url('./base.css');
-
 /* Overrides specific to legal pages */
 .legal-content {
     padding-top: 10rem;
@@ -15,7 +13,7 @@
     text-align: center;
 }
 
-.legal-content h2 {
+.legal-heading {
     font-size: clamp(1.8rem, 4vw, 2.4rem);
     border-bottom: 2px solid var(--accent-wisdom);
     padding-bottom: 0.75rem;

--- a/css/terapia-online.css
+++ b/css/terapia-online.css
@@ -1,4 +1,3 @@
-@import url('./base.css');
 @import url('./common.css');
 @import url('./hero.css');
 @import url('./testimonios.css');

--- a/css/terapia-pareja.css
+++ b/css/terapia-pareja.css
@@ -1,4 +1,3 @@
-@import url('./base.css');
 @import url('./common.css');
 @import url('./hero.css');
 @import url('./testimonios.css');

--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
     }
     </style>
 
+    <link rel="stylesheet" href="css/base.css">
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
     <link rel="preload" href="css/home.css" as="style" onload="this.onload=null;this.rel='stylesheet'">

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -42,6 +42,7 @@
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
     }
     </style>
+    <link rel="stylesheet" href="css/base.css">
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
     <link rel="preload" href="css/legal-styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -42,6 +42,7 @@
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
     }
     </style>
+    <link rel="stylesheet" href="css/base.css">
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
     <link rel="preload" href="css/legal-styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
@@ -133,7 +134,7 @@
             <h1>Política de Privacidad</h1>
             <p>La confidencialidad y la seguridad son valores primordiales y, en consecuencia, asumo el compromiso de garantizar la privacidad del Usuario en todo momento y de no recabar información innecesaria. A continuación, le proporcionamos toda la información necesaria sobre nuestra Política de Privacidad en relación con los datos personales que recabamos.</p>
             
-            <h2>1. Responsable del Tratamiento</h2>
+            <h2 class="legal-heading">1. Responsable del Tratamiento</h2>
             <div class="responsible-details">
                 <p><strong>Francisco Javier Cáceres Velasco</strong></p>
                 <p>NIF: 40439688F</p>
@@ -142,7 +143,7 @@
                 <p>Email: javicaceres@cop.es</p>
             </div>
 
-            <h2>2. Finalidades, Legitimación y Conservación</h2>
+            <h2 class="legal-heading">2. Finalidades, Legitimación y Conservación</h2>
             
             <h3 class="legal-subheading">Contacto a través de Email, Teléfono o WhatsApp</h3>
             <p><strong>Finalidad:</strong> Facilitarle un medio para que pueda ponerse en contacto conmigo y contestar a sus solicitudes de información y citas.</p>
@@ -153,10 +154,10 @@
             <p>El suministro de datos personales requiere una edad mínima de 18 años o, en su caso, disponer de capacidad jurídica suficiente para contratar.</p>
             <p>Los datos personales solicitados son necesarios para gestionar sus solicitudes. Si no nos los facilita, no podremos atenderle correctamente.</p>
 
-            <h2>3. Destinatarios de sus Datos</h2>
+            <h2 class="legal-heading">3. Destinatarios de sus Datos</h2>
             <p>Sus datos son confidenciales y no se cederán a terceros, salvo que exista obligación legal. El compromiso de confidencialidad profesional está garantizado por el Código Deontológico del Psicólogo.</p>
 
-            <h2>4. Derechos en Relación con sus Datos Personales</h2>
+            <h2 class="legal-heading">4. Derechos en Relación con sus Datos Personales</h2>
             <p>Cualquier persona puede retirar su consentimiento en cualquier momento. Igualmente, puede ejercer los siguientes derechos:</p>
             <ul>
                 <li><strong>Acceso:</strong> Conocer qué datos personales tenemos sobre usted.</li>
@@ -171,10 +172,10 @@
             
             <p>En caso de divergencias, puede presentar una reclamación ante la Agencia Española de Protección de Datos (<a href="https://www.aepd.es" target="_blank" rel="noopener noreferrer">www.aepd.es</a>).</p>
 
-            <h2>5. Seguridad de sus Datos Personales</h2>
+            <h2 class="legal-heading">5. Seguridad de sus Datos Personales</h2>
             <p>Con el objetivo de salvaguardar la seguridad de sus datos personales, le informamos que hemos adoptado todas las medidas de índole técnica y organizativa necesarias para garantizar la seguridad de los datos personales suministrados de acuerdo con lo establecido en el Reglamento General de Protección de Datos (RGPD).</p>
 
-            <h2>6. Actualización de sus Datos</h2>
+            <h2 class="legal-heading">6. Actualización de sus Datos</h2>
             <p>Es importante que para que podamos mantener sus datos personales actualizados, nos informe siempre que haya habido alguna modificación en ellos; en caso contrario, no respondemos de la veracidad de los mismos.</p>
             
             <p style="margin-top: 3rem; font-size: 0.9rem; color: var(--text-medium);">Última actualización: Octubre 2025</p>

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -96,6 +96,7 @@
     }
     </style>
     
+    <link rel="stylesheet" href="css/base.css">
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
     <link rel="preload" href="css/terapia-online.css" as="style" onload="this.onload=null;this.rel='stylesheet'">

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -95,6 +95,7 @@
     }
     </style>
     
+    <link rel="stylesheet" href="css/base.css">
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
     <link rel="preload" href="css/terapia-pareja.css" as="style" onload="this.onload=null;this.rel='stylesheet'">


### PR DESCRIPTION
## Summary
- add the shared heading scale tokens and rules to css/base.css
- load css/base.css explicitly on every public page and rely on classes for legal heading styling

## Files
- css/base.css
- css/home.css
- css/legal-styles.css
- css/terapia-online.css
- css/terapia-pareja.css
- index.html
- terapia-online.html
- terapia-pareja.html
- aviso-legal.html
- politica-privacidad.html
- politica-cookies.html
- codigo-deontologico.html

## Nota
- El aviso H1UserAgentFontSizeInSection desaparece en Lighthouse móvil/desktop

------
https://chatgpt.com/codex/tasks/task_e_68e297e6e8c88325a0a8ab626f091d8c