### PR TITLE
Perf Desktop — Caza y fix de CLS (detector + parches mínimos)

### DIFF
--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -23,6 +23,10 @@
     font-weight: 400;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-regular.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
 
     @font-face {
@@ -31,6 +35,10 @@
     font-weight: 600;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-600.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
 
     @font-face {
@@ -39,6 +47,30 @@
     font-weight: 700;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
+    }
+    .header {
+        height: 90px;
+        min-height: 90px;
+    }
+    .nav {
+        min-height: 90px;
+    }
+    i[class*="fa-"] {
+        display: inline-block;
+        width: 1.25em;
+        min-width: 1.25em;
+        text-align: center;
+    }
+    .hamburger-menu {
+        width: 44px;
+        height: 44px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
     }
     </style>
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
@@ -61,11 +93,12 @@
     <header class="header" id="mainHeader">
         <nav class="nav container">
             <a href="index.html" class="logo-container">
-                <img src="images/logo-javi-caceres-horizontal.svg" 
-                    alt="Javi Cáceres Psicólogo - Logo profesional" 
-                    class="logo-img" 
-                    width="240" 
+                <img src="images/logo-javi-caceres-horizontal.svg"
+                    alt="Javi Cáceres Psicólogo - Logo profesional"
+                    class="logo-img"
+                    width="240"
                     height="70"
+                    decoding="async"
                     fetchpriority="high">
             </a>
             <ul class="nav-menu">
@@ -164,10 +197,11 @@
             <div class="footer-col">
                 <h4>Javi Cáceres Psicólogo</h4>
                 <p>Psicólogo Sanitario en Roses (Girona) y Online. Col. 16.772.</p>
-                <img src="images/colegio-psicologos.webp" 
+                <img src="images/colegio-psicologos.webp"
                     alt="Logo del Col·legi Oficial de Psicologia de Catalunya"
                     width="500"
                     height="224"
+                    decoding="async"
                     style="max-width: 200px; height: auto; margin-top: 1rem; border-radius: 8px;">
             </div>
             <div class="footer-col">
@@ -181,9 +215,9 @@
             <div class="footer-col">
                 <h4>Contacto</h4>
                 <ul>
-                    <li><i class="fas fa-map-marker-alt" style="margin-right: 0.5rem;"></i>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
-                    <li><a href="tel:+34621372442"><i class="fas fa-phone" style="margin-right: 0.5rem;"></i>621 372 442</a></li>
-                    <li><a href="mailto:javicaceres@cop.es"><i class="fas fa-envelope" style="margin-right: 0.5rem;"></i>javicaceres@cop.es</a></li>
+                    <li><i class="fas fa-map-marker-alt icon-inline" aria-hidden="true"></i>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
+                    <li><a href="tel:+34621372442"><i class="fas fa-phone icon-inline" aria-hidden="true"></i>621 372 442</a></li>
+                    <li><a href="mailto:javicaceres@cop.es"><i class="fas fa-envelope icon-inline" aria-hidden="true"></i>javicaceres@cop.es</a></li>
                 </ul>
             </div>
             <div class="footer-col">

--- a/codigo-deontologico.html
+++ b/codigo-deontologico.html
@@ -24,6 +24,10 @@
     font-weight: 400;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-regular.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
 
     @font-face {
@@ -32,6 +36,10 @@
     font-weight: 600;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-600.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
 
     @font-face {
@@ -40,6 +48,30 @@
     font-weight: 700;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
+    }
+    .header {
+        height: 90px;
+        min-height: 90px;
+    }
+    .nav {
+        min-height: 90px;
+    }
+    i[class*="fa-"] {
+        display: inline-block;
+        width: 1.25em;
+        min-width: 1.25em;
+        text-align: center;
+    }
+    .hamburger-menu {
+        width: 44px;
+        height: 44px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
     }
     </style>
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
@@ -62,11 +94,12 @@
     <header class="header" id="mainHeader">
         <nav class="nav container">
             <a href="index.html" class="logo-container">
-                <img src="images/logo-javi-caceres-horizontal.svg" 
-                    alt="Javi Cáceres Psicólogo - Logo profesional" 
-                    class="logo-img" 
-                    width="240" 
+                <img src="images/logo-javi-caceres-horizontal.svg"
+                    alt="Javi Cáceres Psicólogo - Logo profesional"
+                    class="logo-img"
+                    width="240"
                     height="70"
+                    decoding="async"
                     fetchpriority="high">
             </a>
             <ul class="nav-menu">
@@ -101,7 +134,7 @@
             <p style="margin-top: 2rem;">Para una consulta detallada del documento completo, puede acceder al código deontológico vigente directamente:</p>
             <p style="text-align: center; margin: 2rem 0;">
                 <a href="https://arxiu.copc.cat/adjuntos/adjunto_188.1524062657.pdf" target="_blank" rel="noopener noreferrer" style="font-size: 1.1rem;">
-                    <i class="fas fa-file-pdf" style="margin-right: 0.5rem;"></i>
+                    <i class="fas fa-file-pdf icon-inline" aria-hidden="true"></i>
                     <strong>Consultar el Código Deontológico del COPC (PDF)</strong>
                 </a>
             </p>
@@ -152,10 +185,11 @@
             <div class="footer-col">
                 <h4>Javi Cáceres Psicólogo</h4>
                 <p>Psicólogo Sanitario en Roses (Girona) y Online. Col. 16.772.</p>
-                <img src="images/colegio-psicologos.webp" 
+                <img src="images/colegio-psicologos.webp"
                     alt="Logo del Col·legi Oficial de Psicologia de Catalunya"
                     width="500"
                     height="224"
+                    decoding="async"
                     style="max-width: 200px; height: auto; margin-top: 1rem; border-radius: 8px;">
             </div>
             <div class="footer-col">
@@ -169,9 +203,9 @@
             <div class="footer-col">
                 <h4>Contacto</h4>
                 <ul>
-                    <li><i class="fas fa-map-marker-alt" style="margin-right: 0.5rem;"></i>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
-                    <li><a href="tel:+34621372442"><i class="fas fa-phone" style="margin-right: 0.5rem;"></i>621 372 442</a></li>
-                    <li><a href="mailto:javicaceres@cop.es"><i class="fas fa-envelope" style="margin-right: 0.5rem;"></i>javicaceres@cop.es</a></li>
+                    <li><i class="fas fa-map-marker-alt icon-inline" aria-hidden="true"></i>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
+                    <li><a href="tel:+34621372442"><i class="fas fa-phone icon-inline" aria-hidden="true"></i>621 372 442</a></li>
+                    <li><a href="mailto:javicaceres@cop.es"><i class="fas fa-envelope icon-inline" aria-hidden="true"></i>javicaceres@cop.es</a></li>
                 </ul>
             </div>
             <div class="footer-col">

--- a/css/legal-styles.css
+++ b/css/legal-styles.css
@@ -71,6 +71,7 @@ strong { color: var(--text-strongest); }
     z-index: 100;
     border-bottom: var(--border-width) solid transparent;
     transition: background 0.3s, border-color 0.3s, box-shadow 0.3s;
+    min-height: 90px;
 }
 
 .header.scrolled {
@@ -84,6 +85,7 @@ strong { color: var(--text-strongest); }
     justify-content: space-between;
     align-items: center;
     padding: 1.2rem 1.5rem;
+    min-height: 90px;
 }
 
 .logo-container {
@@ -91,9 +93,25 @@ strong { color: var(--text-strongest); }
     align-items: center;
 }
 
-.logo-img { 
+.logo-img {
     height: 70px;
     width: auto;
+}
+
+i[class*="fa-"] {
+    display: inline-block;
+    width: 1.25em;
+    min-width: 1.25em;
+    text-align: center;
+}
+
+.icon-inline {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25em;
+    min-width: 1.25em;
+    margin-right: 0.5rem;
 }
 
 .nav-menu {
@@ -112,13 +130,17 @@ strong { color: var(--text-strongest); }
 .nav-menu a:hover { color: var(--accent-empathy); text-decoration: none; }
 
 .hamburger-menu {
-    display: block;
     font-size: 1.5rem;
     background: none;
     border: none;
     cursor: pointer;
     color: var(--text-strongest);
     z-index: 101;
+    width: 44px;
+    height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .mobile-nav-panel {

--- a/css/styles.css
+++ b/css/styles.css
@@ -88,6 +88,7 @@ a { color: var(--accent-empathy); text-decoration: none; font-weight: 600; }
     z-index: 100;
     border-bottom: var(--border-width) solid transparent;
     transition: background 0.3s, border-color 0.3s, box-shadow 0.3s;
+    min-height: 90px;
 }
 
 .header.scrolled {
@@ -101,6 +102,7 @@ a { color: var(--accent-empathy); text-decoration: none; font-weight: 600; }
     justify-content: space-between;
     align-items: center;
     padding: 1.2rem 1.5rem;
+    min-height: 90px;
 }
 
 .logo-container {
@@ -108,9 +110,25 @@ a { color: var(--accent-empathy); text-decoration: none; font-weight: 600; }
     align-items: center;
 }
 
-.logo-img { 
+.logo-img {
     height: 70px;
     width: auto;
+}
+
+i[class*="fa-"] {
+    display: inline-block;
+    width: 1.25em;
+    min-width: 1.25em;
+    text-align: center;
+}
+
+.icon-inline {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25em;
+    min-width: 1.25em;
+    margin-right: 0.5rem;
 }
 
 .nav-menu {
@@ -129,13 +147,17 @@ a { color: var(--accent-empathy); text-decoration: none; font-weight: 600; }
 .nav-menu a:not(.btn):hover { color: var(--accent-empathy); }
 
 .hamburger-menu {
-    display: block;
     font-size: 1.5rem;
     background: none;
     border: none;
     cursor: pointer;
     color: var(--text-strongest);
     z-index: 101;
+    width: 44px;
+    height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .mobile-nav-panel {
@@ -768,6 +790,10 @@ section#especializacion .grid-2 > a {
 
 .cookie-consent-banner.active {
     transform: translateY(0);
+}
+
+.cookie-consent-banner.dismissed {
+    transform: translateY(100%);
 }
 
 .cookie-consent-banner p {

--- a/index.html
+++ b/index.html
@@ -44,6 +44,10 @@
     font-weight: 400;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-regular.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
 
     @font-face {
@@ -52,6 +56,10 @@
     font-weight: 600;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-600.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
 
     @font-face {
@@ -60,6 +68,10 @@
     font-weight: 700;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
     </style>
     
@@ -79,6 +91,10 @@
         width: 100%;
         z-index: 100;
         height: 90px;
+        min-height: 90px;
+    }
+    .nav {
+        min-height: 90px;
     }
     .hero {
         padding-top: 8rem;
@@ -86,6 +102,19 @@
     .logo-container {
         width: 240px;
         height: 70px;
+    }
+    i[class*="fa-"] {
+        display: inline-block;
+        width: 1.25em;
+        min-width: 1.25em;
+        text-align: center;
+    }
+    .hamburger-menu {
+        width: 44px;
+        height: 44px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
     }
     @media (max-width: 768px) {
         .logo-container {
@@ -163,11 +192,12 @@
     <header class="header" id="mainHeader">
         <nav class="nav container">
             <a href="index.html" class="logo-container">
-                <img src="images/logo-javi-caceres-horizontal.svg" 
-                    alt="Javi Cáceres Psicólogo - Logo profesional" 
-                    class="logo-img" 
-                    width="240" 
+                <img src="images/logo-javi-caceres-horizontal.svg"
+                    alt="Javi Cáceres Psicólogo - Logo profesional"
+                    class="logo-img"
+                    width="240"
                     height="70"
+                    decoding="async"
                     fetchpriority="high">
             </a>
             <ul class="nav-menu">
@@ -204,7 +234,7 @@
                 <h1>¿La ansiedad o la tristeza te están alejando de la vida que deseas?</h1>
                 <p class="subtitle">No tienes por qué seguir así. Te ofrezco una terapia breve y colaborativa, un espacio de confianza donde, juntos, encontraremos tus recursos para que recuperes la calma, la claridad y el control.</p>
                 <div class="hero-actions">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20para%20una%20cita%20presencial." target="_blank" class="btn btn-primary"><i class="fab fa-whatsapp"></i> Contactar por WhatsApp</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20para%20una%20cita%20presencial." target="_blank" class="btn btn-primary"><i class="fab fa-whatsapp" aria-hidden="true"></i> Contactar por WhatsApp</a>
                     <a href="#tarifas" class="btn btn-secondary">Ver Tarifas</a>
                 </div>
             </div>
@@ -496,7 +526,7 @@
                 <h2>El cambio empieza con una conversación. ¿Hablamos?</h2>
                 <p>Dar el primer paso es el más valiente. Escríbeme sin compromiso para resolver cualquier duda o para concertar una primera cita. Estoy aquí para escucharte.</p>
                 <div class="hero-actions" style="margin-top: 2rem;">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20para%20una%20cita." target="_blank" class="btn btn-primary"><i class="fab fa-whatsapp"></i> Escríbeme por WhatsApp</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20para%20una%20cita." target="_blank" class="btn btn-primary"><i class="fab fa-whatsapp" aria-hidden="true"></i> Escríbeme por WhatsApp</a>
                 </div>
             </div>
         </section>
@@ -507,11 +537,12 @@
             <div class="footer-col">
                 <h4>Javi Cáceres Psicólogo</h4>
                 <p>Psicólogo Sanitario en Roses (Girona) y Online. Col. 16.772.</p>
-                <img src="images/colegio-psicologos.webp" 
+                <img src="images/colegio-psicologos.webp"
                     alt="Logo del Col·legi Oficial de Psicologia de Catalunya"
                     width="500"
                     height="224"
                     loading="lazy"
+                    decoding="async"
                     style="max-width: 200px; height: auto; margin-top: 1rem; border-radius: 8px;">
             </div>
             <div class="footer-col">
@@ -526,13 +557,13 @@
                 <h4>Contacto</h4>
                 <ul>
                     <li>
-                        <i class="fas fa-map-marker-alt" style="margin-right: 0.5rem;"></i>
+                        <i class="fas fa-map-marker-alt icon-inline" aria-hidden="true"></i>
                         <a href="https://maps.app.goo.gl/qK8TCrotW8m6P8oCA" target="_blank" rel="noopener">
                             Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses
                         </a>
                     </li>
-                    <li><a href="tel:+34621372442"><i class="fas fa-phone" style="margin-right: 0.5rem;"></i>621 372 442</a></li>
-                    <li><a href="mailto:javicaceres@cop.es"><i class="fas fa-envelope" style="margin-right: 0.5rem;"></i>javicaceres@cop.es</a></li>
+                    <li><a href="tel:+34621372442"><i class="fas fa-phone icon-inline" aria-hidden="true"></i>621 372 442</a></li>
+                    <li><a href="mailto:javicaceres@cop.es"><i class="fas fa-envelope icon-inline" aria-hidden="true"></i>javicaceres@cop.es</a></li>
                 </ul>
             </div>
             <div class="footer-col">
@@ -548,7 +579,7 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
 
-    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><i class="fab fa-whatsapp"></i></a>
+    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><i class="fab fa-whatsapp" aria-hidden="true"></i></a>
 
     <div class="cookie-consent-banner" id="cookie-banner">
         <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información</a>.</p>

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,23 @@
+if (typeof window !== 'undefined' && window.location.search.includes('cls-debug=1') && 'PerformanceObserver' in window) {
+    try {
+        const clsObserver = new PerformanceObserver((list) => {
+            for (const entry of list.getEntries()) {
+                if (entry.hadRecentInput) continue;
+                const sources = entry.sources || [];
+                sources.forEach((src) => {
+                    const el = src.node;
+                    if (!el || typeof el.getBoundingClientRect !== 'function') return;
+                    el.style.outline = '2px solid rgba(255, 0, 0, 0.8)';
+                    console.warn('CLS source:', el, 'score', entry.value, entry);
+                });
+            }
+        });
+        clsObserver.observe({ type: 'layout-shift', buffered: true });
+    } catch (error) {
+        console.warn('CLS debug observer failed', error);
+    }
+}
+
 document.addEventListener('DOMContentLoaded', function() {
     // Header scroll effect - PASSIVE LISTENER
     const header = document.getElementById('mainHeader');
@@ -173,15 +193,21 @@ document.addEventListener('DOMContentLoaded', function() {
     const acceptCookiesBtn = document.getElementById('accept-cookies-btn');
 
     if (cookieBanner && acceptCookiesBtn) {
+        const revealBanner = () => {
+            cookieBanner.classList.remove('dismissed');
+            cookieBanner.classList.add('active');
+        };
+
         if (!getCookie('cookies_accepted')) {
-            setTimeout(() => {
-                cookieBanner.classList.add('active');
-            }, 1500);
+            setTimeout(revealBanner, 1500);
+        } else {
+            cookieBanner.classList.add('dismissed');
         }
 
         acceptCookiesBtn.addEventListener('click', () => {
             setCookie('cookies_accepted', 'true', 365);
-            cookieBanner.style.transform = 'translateY(100%)';
+            cookieBanner.classList.remove('active');
+            cookieBanner.classList.add('dismissed');
         });
     }
 

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -24,6 +24,10 @@
     font-weight: 400;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-regular.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
 
     @font-face {
@@ -32,6 +36,10 @@
     font-weight: 600;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-600.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
 
     @font-face {
@@ -40,6 +48,30 @@
     font-weight: 700;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
+    }
+    .header {
+        height: 90px;
+        min-height: 90px;
+    }
+    .nav {
+        min-height: 90px;
+    }
+    i[class*="fa-"] {
+        display: inline-block;
+        width: 1.25em;
+        min-width: 1.25em;
+        text-align: center;
+    }
+    .hamburger-menu {
+        width: 44px;
+        height: 44px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
     }
     </style>
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
@@ -62,11 +94,12 @@
     <header class="header" id="mainHeader">
         <nav class="nav container">
             <a href="index.html" class="logo-container">
-                <img src="images/logo-javi-caceres-horizontal.svg" 
-                    alt="Javi Cáceres Psicólogo - Logo profesional" 
-                    class="logo-img" 
-                    width="240" 
+                <img src="images/logo-javi-caceres-horizontal.svg"
+                    alt="Javi Cáceres Psicólogo - Logo profesional"
+                    class="logo-img"
+                    width="240"
                     height="70"
+                    decoding="async"
                     fetchpriority="high">
             </a>
             <ul class="nav-menu">
@@ -144,10 +177,11 @@
             <div class="footer-col">
                 <h4>Javi Cáceres Psicólogo</h4>
                 <p>Psicólogo Sanitario en Roses (Girona) y Online. Col. 16.772.</p>
-                <img src="images/colegio-psicologos.webp" 
+                <img src="images/colegio-psicologos.webp"
                     alt="Logo del Col·legi Oficial de Psicologia de Catalunya"
                     width="500"
                     height="224"
+                    decoding="async"
                     style="max-width: 200px; height: auto; margin-top: 1rem; border-radius: 8px;">
             </div>
             <div class="footer-col">
@@ -161,9 +195,9 @@
             <div class="footer-col">
                 <h4>Contacto</h4>
                 <ul>
-                    <li><i class="fas fa-map-marker-alt" style="margin-right: 0.5rem;"></i>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
-                    <li><a href="tel:+34621372442"><i class="fas fa-phone" style="margin-right: 0.5rem;"></i>621 372 442</a></li>
-                    <li><a href="mailto:javicaceres@cop.es"><i class="fas fa-envelope" style="margin-right: 0.5rem;"></i>javicaceres@cop.es</a></li>
+                    <li><i class="fas fa-map-marker-alt icon-inline" aria-hidden="true"></i>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
+                    <li><a href="tel:+34621372442"><i class="fas fa-phone icon-inline" aria-hidden="true"></i>621 372 442</a></li>
+                    <li><a href="mailto:javicaceres@cop.es"><i class="fas fa-envelope icon-inline" aria-hidden="true"></i>javicaceres@cop.es</a></li>
                 </ul>
             </div>
             <div class="footer-col">

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -24,6 +24,10 @@
     font-weight: 400;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-regular.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
 
     @font-face {
@@ -32,6 +36,10 @@
     font-weight: 600;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-600.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
 
     @font-face {
@@ -40,6 +48,30 @@
     font-weight: 700;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
+    }
+    .header {
+        height: 90px;
+        min-height: 90px;
+    }
+    .nav {
+        min-height: 90px;
+    }
+    i[class*="fa-"] {
+        display: inline-block;
+        width: 1.25em;
+        min-width: 1.25em;
+        text-align: center;
+    }
+    .hamburger-menu {
+        width: 44px;
+        height: 44px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
     }
     </style>
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
@@ -62,11 +94,12 @@
     <header class="header" id="mainHeader">
         <nav class="nav container">
             <a href="index.html" class="logo-container">
-                <img src="images/logo-javi-caceres-horizontal.svg" 
-                    alt="Javi Cáceres Psicólogo - Logo profesional" 
-                    class="logo-img" 
-                    width="240" 
+                <img src="images/logo-javi-caceres-horizontal.svg"
+                    alt="Javi Cáceres Psicólogo - Logo profesional"
+                    class="logo-img"
+                    width="240"
                     height="70"
+                    decoding="async"
                     fetchpriority="high">
             </a>
             <ul class="nav-menu">
@@ -146,10 +179,11 @@
             <div class="footer-col">
                 <h4>Javi Cáceres Psicólogo</h4>
                 <p>Psicólogo Sanitario en Roses (Girona) y Online. Col. 16.772.</p>
-                <img src="images/colegio-psicologos.webp" 
+                <img src="images/colegio-psicologos.webp"
                     alt="Logo del Col·legi Oficial de Psicologia de Catalunya"
                     width="500"
                     height="224"
+                    decoding="async"
                     style="max-width: 200px; height: auto; margin-top: 1rem; border-radius: 8px;">
             </div>
             <div class="footer-col">
@@ -163,9 +197,9 @@
             <div class="footer-col">
                 <h4>Contacto</h4>
                 <ul>
-                    <li><i class="fas fa-map-marker-alt" style="margin-right: 0.5rem;"></i>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
-                    <li><a href="tel:+34621372442"><i class="fas fa-phone" style="margin-right: 0.5rem;"></i>621 372 442</a></li>
-                    <li><a href="mailto:javicaceres@cop.es"><i class="fas fa-envelope" style="margin-right: 0.5rem;"></i>javicaceres@cop.es</a></li>
+                    <li><i class="fas fa-map-marker-alt icon-inline" aria-hidden="true"></i>Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses</li>
+                    <li><a href="tel:+34621372442"><i class="fas fa-phone icon-inline" aria-hidden="true"></i>621 372 442</a></li>
+                    <li><a href="mailto:javicaceres@cop.es"><i class="fas fa-envelope icon-inline" aria-hidden="true"></i>javicaceres@cop.es</a></li>
                 </ul>
             </div>
             <div class="footer-col">

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -44,6 +44,10 @@
     font-weight: 400;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-regular.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
 
     @font-face {
@@ -52,6 +56,10 @@
     font-weight: 600;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-600.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
 
     @font-face {
@@ -60,6 +68,10 @@
     font-weight: 700;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
     </style>
 
@@ -79,6 +91,10 @@
         width: 100%;
         z-index: 100;
         height: 90px;
+        min-height: 90px;
+    }
+    .nav {
+        min-height: 90px;
     }
     .hero {
         padding-top: 8rem;
@@ -86,6 +102,19 @@
     .logo-container {
         width: 240px;
         height: 70px;
+    }
+    i[class*="fa-"] {
+        display: inline-block;
+        width: 1.25em;
+        min-width: 1.25em;
+        text-align: center;
+    }
+    .hamburger-menu {
+        width: 44px;
+        height: 44px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
     }
     @media (max-width: 768px) {
         .logo-container {
@@ -130,11 +159,12 @@
     <header class="header" id="mainHeader">
         <nav class="nav container">
             <a href="index.html" class="logo-container">
-                <img src="images/logo-javi-caceres-horizontal.svg" 
-                    alt="Javi Cáceres Psicólogo - Logo profesional" 
-                    class="logo-img" 
-                    width="240" 
+                <img src="images/logo-javi-caceres-horizontal.svg"
+                    alt="Javi Cáceres Psicólogo - Logo profesional"
+                    class="logo-img"
+                    width="240"
                     height="70"
+                    decoding="async"
                     fetchpriority="high">
             </a>
             <ul class="nav-menu">
@@ -171,7 +201,7 @@
                 <h1>¿La distancia o la falta de tiempo te impiden cuidar de tu bienestar?</h1>
                 <p class="subtitle">La terapia online te ofrece el mismo nivel de calidad y cercanía que la presencial, pero con la flexibilidad que necesitas. Desde tu casa, desde donde estés, cuando mejor te venga.</p>
                 <div class="hero-actions">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" class="btn btn-primary"><i class="fab fa-whatsapp"></i> Empezar Ahora</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" class="btn btn-primary"><i class="fab fa-whatsapp" aria-hidden="true"></i> Empezar Ahora</a>
                 </div>
             </div>
         </section>
@@ -399,7 +429,7 @@
                 <h2>Tu bienestar no puede esperar. Empieza hoy.</h2>
                 <p>No dejes que la falta de tiempo o la ubicación sean un obstáculo para sentirte mejor. La terapia breve online es una puerta abierta a tu cambio personal. ¿Hablamos?</p>
                 <div class="hero-actions" style="margin-top: 2rem;">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" class="btn btn-primary"><i class="fab fa-whatsapp"></i> Empezar Terapia Online</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" class="btn btn-primary"><i class="fab fa-whatsapp" aria-hidden="true"></i> Empezar Terapia Online</a>
                 </div>
             </div>
         </section>
@@ -410,11 +440,12 @@
             <div class="footer-col">
                 <h4>Javi Cáceres Psicólogo</h4>
                 <p>Psicólogo Sanitario en Roses (Girona) y Online. Col. 16.772.</p>
-                <img src="images/colegio-psicologos.webp" 
+                <img src="images/colegio-psicologos.webp"
                     alt="Logo del Col·legi Oficial de Psicologia de Catalunya"
                     width="500"
                     height="224"
                     loading="lazy"
+                    decoding="async"
                     style="max-width: 200px; height: auto; margin-top: 1rem; border-radius: 8px;">
             </div>
             <div class="footer-col">
@@ -429,13 +460,13 @@
                 <h4>Contacto</h4>
                 <ul>
                     <li>
-                        <i class="fas fa-map-marker-alt" style="margin-right: 0.5rem;"></i>
+                        <i class="fas fa-map-marker-alt icon-inline" aria-hidden="true"></i>
                         <a href="https://maps.app.goo.gl/qK8TCrotW8m6P8oCA" target="_blank" rel="noopener">
                             Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses
                         </a>
                     </li>
-                    <li><a href="tel:+34621372442"><i class="fas fa-phone" style="margin-right: 0.5rem;"></i>621 372 442</a></li>
-                    <li><a href="mailto:javicaceres@cop.es"><i class="fas fa-envelope" style="margin-right: 0.5rem;"></i>javicaceres@cop.es</a></li>
+                    <li><a href="tel:+34621372442"><i class="fas fa-phone icon-inline" aria-hidden="true"></i>621 372 442</a></li>
+                    <li><a href="mailto:javicaceres@cop.es"><i class="fas fa-envelope icon-inline" aria-hidden="true"></i>javicaceres@cop.es</a></li>
                 </ul>
             </div>
             <div class="footer-col">
@@ -451,7 +482,7 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
 
-    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><i class="fab fa-whatsapp"></i></a>
+    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><i class="fab fa-whatsapp" aria-hidden="true"></i></a>
 
     <div class="cookie-consent-banner" id="cookie-banner">
         <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información</a>.</p>

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -43,6 +43,10 @@
     font-weight: 400;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-regular.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
 
     @font-face {
@@ -51,6 +55,10 @@
     font-weight: 600;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-600.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
 
     @font-face {
@@ -59,6 +67,10 @@
     font-weight: 700;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
     }
     </style>
 
@@ -78,6 +90,10 @@
         width: 100%;
         z-index: 100;
         height: 90px;
+        min-height: 90px;
+    }
+    .nav {
+        min-height: 90px;
     }
     .hero {
         padding-top: 8rem;
@@ -85,6 +101,19 @@
     .logo-container {
         width: 240px;
         height: 70px;
+    }
+    i[class*="fa-"] {
+        display: inline-block;
+        width: 1.25em;
+        min-width: 1.25em;
+        text-align: center;
+    }
+    .hamburger-menu {
+        width: 44px;
+        height: 44px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
     }
     @media (max-width: 768px) {
         .logo-container {
@@ -138,11 +167,12 @@
     <header class="header" id="mainHeader">
         <nav class="nav container">
             <a href="index.html" class="logo-container">
-                <img src="images/logo-javi-caceres-horizontal.svg" 
-                    alt="Javi Cáceres Psicólogo - Logo profesional" 
-                    class="logo-img" 
-                    width="240" 
+                <img src="images/logo-javi-caceres-horizontal.svg"
+                    alt="Javi Cáceres Psicólogo - Logo profesional"
+                    class="logo-img"
+                    width="240"
                     height="70"
+                    decoding="async"
                     fetchpriority="high">
             </a>
             <ul class="nav-menu">
@@ -179,7 +209,7 @@
                 <h1>¿Sentís que la distancia y las discusiones se han adueñado de vuestra relación?</h1>
                 <p class="subtitle">Recuperar la conexión, la amistad y la pasión es posible. Os ofrezco un método de terapia de pareja basado en la ciencia (Gottman) y en vuestras propias fortalezas para reconstruir el "nosotros" que un día fuisteis.</p>
                 <div class="hero-actions">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" class="btn btn-primary"><i class="fab fa-whatsapp"></i> Iniciar el Cambio</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" class="btn btn-primary"><i class="fab fa-whatsapp" aria-hidden="true"></i> Iniciar el Cambio</a>
                 </div>
             </div>
         </section>
@@ -388,7 +418,7 @@
                 <h2>Construid el futuro que deseáis, juntos.</h2>
                 <p>Dar el paso de pedir ayuda como pareja es un acto de valentía y un gran gesto de amor hacia la relación. Si estáis listos para empezar a cambiar las cosas, estoy aquí para guiaros.</p>
                 <div class="hero-actions" style="margin-top: 2rem;">
-                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" class="btn btn-primary"><i class="fab fa-whatsapp"></i> Contactar para Terapia de Pareja</a>
+                    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" class="btn btn-primary"><i class="fab fa-whatsapp" aria-hidden="true"></i> Contactar para Terapia de Pareja</a>
                 </div>
             </div>
         </section>
@@ -399,11 +429,12 @@
             <div class="footer-col">
                 <h4>Javi Cáceres Psicólogo</h4>
                 <p>Psicólogo Sanitario en Roses (Girona) y Online. Col. 16.772.</p>
-                <img src="images/colegio-psicologos.webp" 
+                <img src="images/colegio-psicologos.webp"
                     alt="Logo del Col·legi Oficial de Psicologia de Catalunya"
                     width="500"
                     height="224"
                     loading="lazy"
+                    decoding="async"
                     style="max-width: 200px; height: auto; margin-top: 1rem; border-radius: 8px;">
             </div>
             <div class="footer-col">
@@ -418,13 +449,13 @@
                 <h4>Contacto</h4>
                 <ul>
                     <li>
-                        <i class="fas fa-map-marker-alt" style="margin-right: 0.5rem;"></i>
+                        <i class="fas fa-map-marker-alt icon-inline" aria-hidden="true"></i>
                         <a href="https://maps.app.goo.gl/qK8TCrotW8m6P8oCA" target="_blank" rel="noopener">
                             Carrer del Doctor Hermenegild Arruga, 76, 2n, 2a, Roses
                         </a>
                     </li>
-                    <li><a href="tel:+34621372442"><i class="fas fa-phone" style="margin-right: 0.5rem;"></i>621 372 442</a></li>
-                    <li><a href="mailto:javicaceres@cop.es"><i class="fas fa-envelope" style="margin-right: 0.5rem;"></i>javicaceres@cop.es</a></li>
+                    <li><a href="tel:+34621372442"><i class="fas fa-phone icon-inline" aria-hidden="true"></i>621 372 442</a></li>
+                    <li><a href="mailto:javicaceres@cop.es"><i class="fas fa-envelope icon-inline" aria-hidden="true"></i>javicaceres@cop.es</a></li>
                 </ul>
             </div>
             <div class="footer-col">
@@ -440,7 +471,7 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
 
-    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><i class="fab fa-whatsapp"></i></a>
+    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp"><i class="fab fa-whatsapp" aria-hidden="true"></i></a>
 
     <div class="cookie-consent-banner" id="cookie-banner">
         <p>Este sitio web utiliza cookies para mejorar la experiencia del usuario. <a href="politica-cookies.html">Más información</a>.</p>


### PR DESCRIPTION
## Summary
- add a CLS debug observer gated behind the `cls-debug` query flag and adjust the cookie banner logic to rely on class toggles
- harden layout stability with Inter font metrics, fixed header sizing, and icon placeholders across shared templates and stylesheets
- supply intrinsic dimensions/decoding hints on header and footer assets to avoid flashes, mirroring the updates on every public page

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e2beac5a44832588b93cf7b5f6a9ad