### PR TITLE
Perf Desktop — Estabilizar CSS crítico y tipografía (bajar CLS)

### DIFF
--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -41,7 +41,7 @@
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
     }
     </style>
-    <link rel="stylesheet" href="css/base.css">
+    <link rel="stylesheet" href="/css/base.css">
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
     <link rel="preload" href="css/legal-styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
@@ -97,7 +97,7 @@
 </head>
 <body>
 
-    <header class="header" id="mainHeader">
+    <header class="header site-header" id="mainHeader">
         <nav class="nav container">
             <a href="index.html" class="logo-container">
                 <img src="images/logo-javi-caceres-horizontal.svg" 

--- a/codigo-deontologico.html
+++ b/codigo-deontologico.html
@@ -42,7 +42,7 @@
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
     }
     </style>
-    <link rel="stylesheet" href="css/base.css">
+    <link rel="stylesheet" href="/css/base.css">
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
     <link rel="preload" href="css/legal-styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
@@ -98,7 +98,7 @@
 </head>
 <body>
 
-    <header class="header" id="mainHeader">
+    <header class="header site-header" id="mainHeader">
         <nav class="nav container">
             <a href="index.html" class="logo-container">
                 <img src="images/logo-javi-caceres-horizontal.svg" 

--- a/css/base.css
+++ b/css/base.css
@@ -17,6 +17,10 @@
     font-weight: 600;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-600.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
 }
 
 @font-face {
@@ -25,6 +29,10 @@
     font-weight: 700;
     font-display: swap;
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+    size-adjust: 102%;
 }
 
 :root {
@@ -70,6 +78,11 @@ body {
     color: var(--text-strong);
     line-height: 1.6;
     font-size: 17px;
+}
+
+html,
+body {
+    font-synthesis-weight: none;
 }
 
 img.icon,
@@ -304,6 +317,13 @@ strong {
     background: rgba(249, 249, 247, 0.85);
     border-bottom-color: rgba(228, 231, 235, 0.3);
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
+}
+
+@media (min-width: 1024px) {
+    header.site-header {
+        min-height: 72px;
+        transition: background 0.3s, border-color 0.3s, box-shadow 0.3s, opacity 0.2s ease, transform 0.2s ease; /* no height transitions */
+    }
 }
 
 .nav {

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
     }
     </style>
 
-    <link rel="stylesheet" href="css/base.css">
+    <link rel="stylesheet" href="/css/base.css">
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
     <link rel="preload" href="css/home.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
@@ -152,7 +152,7 @@
 </head>
 <body>
     
-    <header class="header" id="mainHeader">
+    <header class="header site-header" id="mainHeader">
         <nav class="nav container">
             <a href="index.html" class="logo-container">
                 <img src="images/logo-javi-caceres-horizontal.svg" 

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -42,7 +42,7 @@
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
     }
     </style>
-    <link rel="stylesheet" href="css/base.css">
+    <link rel="stylesheet" href="/css/base.css">
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
     <link rel="preload" href="css/legal-styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
@@ -98,7 +98,7 @@
 </head>
 <body>
 
-    <header class="header" id="mainHeader">
+    <header class="header site-header" id="mainHeader">
         <nav class="nav container">
             <a href="index.html" class="logo-container">
                 <img src="images/logo-javi-caceres-horizontal.svg" 

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -42,7 +42,7 @@
     src: url('/fonts/inter-v20-latin-700.woff2') format('woff2');
     }
     </style>
-    <link rel="stylesheet" href="css/base.css">
+    <link rel="stylesheet" href="/css/base.css">
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
     <link rel="preload" href="css/legal-styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
@@ -98,7 +98,7 @@
 </head>
 <body>
 
-    <header class="header" id="mainHeader">
+    <header class="header site-header" id="mainHeader">
         <nav class="nav container">
             <a href="index.html" class="logo-container">
                 <img src="images/logo-javi-caceres-horizontal.svg" 

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -97,7 +97,7 @@
     }
     </style>
     
-    <link rel="stylesheet" href="css/base.css">
+    <link rel="stylesheet" href="/css/base.css">
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
     <link rel="preload" href="css/terapia-online.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
@@ -154,7 +154,7 @@
 </head>
 <body>
     
-    <header class="header" id="mainHeader">
+    <header class="header site-header" id="mainHeader">
         <nav class="nav container">
             <a href="index.html" class="logo-container">
                 <img src="images/logo-javi-caceres-horizontal.svg" 

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -97,7 +97,7 @@
     }
     </style>
     
-    <link rel="stylesheet" href="css/base.css">
+    <link rel="stylesheet" href="/css/base.css">
     <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
     <link rel="preload" href="css/terapia-pareja.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
@@ -154,7 +154,7 @@
 </head>
 <body>
     
-    <header class="header" id="mainHeader">
+    <header class="header site-header" id="mainHeader">
         <nav class="nav container">
             <a href="index.html" class="logo-container">
                 <img src="images/logo-javi-caceres-horizontal.svg" 


### PR DESCRIPTION
## Resumen
- Cargar `/css/base.css` de forma bloqueante en todas las páginas para evitar saltos al aplicar la hoja base.
- Añadir overrides métricos y `font-display: swap` consistentes a los pesos de Inter y desactivar la síntesis automática de peso.
- Definir una altura mínima de 72px para el header de escritorio y limitar sus transiciones para estabilizar el layout inicial.

## Verificación
- ⚠️ Chrome DevTools → Performance → Record and reload (caché desactivada) *(no disponible en este entorno CLI)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e81964708325ac7f3678946d68ad