### PR TITLE
Perf Desktop — CLS casi 0: CSS en <head>, Inter estable y espacio reservado

### DIFF
--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -15,17 +15,15 @@
     <!-- Fonts Inter (self-hosted per millorar velocitat) -->
     <link rel="preload" href="/fonts/inter-v20-latin-regular.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/inter-v20-latin-600.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="/fonts/inter-v20-latin-700.woff2" as="font" type="font/woff2" crossorigin> 
-    <style>
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-regular.woff2') format('woff2');font-weight:400;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-600.woff2') format('woff2');font-weight:600;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-700.woff2') format('woff2');font-weight:700;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    </style>
-    <link rel="stylesheet" href="/css/base.css">
-    <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
+    <link rel="preload" href="/fonts/inter-v20-latin-700.woff2" as="font" type="font/woff2" crossorigin>
 
-    <link rel="preload" href="css/legal-styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="css/legal-styles.css"></noscript>
+    <link rel="stylesheet" href="/css/base.css">
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/hero.css">
+    <link rel="stylesheet" href="/css/space.css">
+    <link rel="stylesheet" href="/css/testimonios.css">
+    <link rel="stylesheet" href="/css/mapa.css">
+    <link rel="stylesheet" href="/css/legal-styles.css">
 
     <script type="application/ld+json">
     {

--- a/codigo-deontologico.html
+++ b/codigo-deontologico.html
@@ -17,16 +17,13 @@
     <link rel="preload" href="/fonts/inter-v20-latin-600.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/inter-v20-latin-700.woff2" as="font" type="font/woff2" crossorigin>
 
-    <style>
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-regular.woff2') format('woff2');font-weight:400;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-600.woff2') format('woff2');font-weight:600;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-700.woff2') format('woff2');font-weight:700;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    </style>
     <link rel="stylesheet" href="/css/base.css">
-    <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
-
-    <link rel="preload" href="css/legal-styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="css/legal-styles.css"></noscript>
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/hero.css">
+    <link rel="stylesheet" href="/css/space.css">
+    <link rel="stylesheet" href="/css/testimonios.css">
+    <link rel="stylesheet" href="/css/mapa.css">
+    <link rel="stylesheet" href="/css/legal-styles.css">
 
     <script type="application/ld+json">
     {

--- a/css/base.css
+++ b/css/base.css
@@ -174,6 +174,27 @@ strong {
     margin: 0 auto 4rem auto;
 }
 
+@media (min-width: 1024px) {
+    .section-header {
+        min-height: 120px;
+    }
+}
+
+.card {
+    display: flex;
+    flex-direction: column;
+}
+
+@media (min-width: 1024px) {
+    .card {
+        min-height: 320px;
+    }
+
+    .pricing-card {
+        min-height: 520px;
+    }
+}
+
 .section-subtitle {
     color: var(--accent-wisdom);
     font-weight: 600;

--- a/css/hero.css
+++ b/css/hero.css
@@ -37,3 +37,14 @@
         min-height: 320px;
     }
 }
+
+.hero .media-slot {
+    aspect-ratio: 4 / 3;
+    max-width: 100%;
+}
+
+.hero .media-slot img {
+    width: 100%;
+    height: auto;
+    display: block;
+}

--- a/css/testimonios.css
+++ b/css/testimonios.css
@@ -2,6 +2,10 @@
 
 .testimonials-section { background-color: var(--bg-lighter); }
 
+.testimonials-section .carousel {
+    min-height: 220px;
+}
+
 .testimonial-card {
     display: flex;
     flex-direction: column;

--- a/index.html
+++ b/index.html
@@ -32,52 +32,14 @@
     <link rel="preload" href="/fonts/inter-v20-latin-regular.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/inter-v20-latin-600.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/inter-v20-latin-700.woff2" as="font" type="font/woff2" crossorigin>
-    <style>
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-regular.woff2') format('woff2');font-weight:400;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-600.woff2') format('woff2');font-weight:600;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-700.woff2') format('woff2');font-weight:700;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    </style>
-    
-    <!-- CSS CRÍTICO - Previene CLS -->
-    <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-        background-color: #F9F9F7;
-        color: #4A5568;
-        line-height: 1.6;
-    }
-    .header {
-        background: rgba(249, 249, 247, 0.75);
-        backdrop-filter: blur(12px);
-        position: fixed;
-        width: 100%;
-        z-index: 100;
-        height: 90px;
-    }
-    .hero {
-        padding-top: 8rem;
-    }
-    .logo-container {
-        width: 240px;
-        height: 70px;
-    }
-    @media (max-width: 768px) {
-        .logo-container {
-            width: 180px;
-            height: 50px;
-        }
-        .hero {
-            padding-top: 8rem;
-        }
-    }
-    </style>
 
     <link rel="stylesheet" href="/css/base.css">
-    <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
-
-    <link rel="preload" href="css/home.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="css/home.css"></noscript>
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/hero.css">
+    <link rel="stylesheet" href="/css/space.css">
+    <link rel="stylesheet" href="/css/testimonios.css">
+    <link rel="stylesheet" href="/css/mapa.css">
+    <link rel="stylesheet" href="/css/home.css">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -189,17 +151,17 @@
                     <p>La terapia te proporciona las herramientas para dejar atrás el malestar y construir un presente más pleno. Imagina poder gestionar tus emociones, fortalecer tus relaciones y sentirte, por fin, en calma contigo mismo/a.</p>
                 </div>
                 <div class="grid-3">
-                    <div class="info-card">
+                    <div class="info-card card">
                         <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M416 208C416 305.2 330 384 224 384C197.3 384 171.9 379 148.8 370L67.2 413.2C57.9 418.1 46.5 416.4 39 409C31.5 401.6 29.8 390.1 34.8 380.8L70.4 313.6C46.3 284.2 32 247.6 32 208C32 110.8 118 32 224 32C330 32 416 110.8 416 208zM416 576C321.9 576 243.6 513.9 227.2 432C347.2 430.5 451.5 345.1 463 229.3C546.3 248.5 608 317.6 608 400C608 439.6 593.7 476.2 569.6 505.6L605.2 572.8C610.1 582.1 608.4 593.5 601 601C593.6 608.5 582.1 610.2 572.8 605.2L491.2 562C468.1 571 442.7 576 416 576z" fill="currentColor" /></svg></div>
                         <h3>Comunicación Asertiva</h3>
                         <p>Expresa tus necesidades y pon límites de forma clara y respetuosa, mejorando tus vínculos.</p>
                     </div>
-                    <div class="info-card">
+                    <div class="info-card card">
                         <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M184 120C184 89.1 209.1 64 240 64L264 64C281.7 64 296 78.3 296 96L296 544C296 561.7 281.7 576 264 576L232 576C202.2 576 177.1 555.6 170 528C169.3 528 168.7 528 168 528C123.8 528 88 492.2 88 448C88 430 94 413.4 104 400C84.6 385.4 72 362.2 72 336C72 305.1 89.6 278.2 115.2 264.9C108.1 252.9 104 238.9 104 224C104 179.8 139.8 144 184 144L184 120zM456 120L456 144C500.2 144 536 179.8 536 224C536 239 531.9 253 524.8 264.9C550.5 278.2 568 305 568 336C568 362.2 555.4 385.4 536 400C546 413.4 552 430 552 448C552 492.2 516.2 528 472 528C471.3 528 470.7 528 470 528C462.9 555.6 437.8 576 408 576L376 576C358.3 576 344 561.7 344 544L344 96C344 78.3 358.3 64 376 64L400 64C430.9 64 456 89.1 456 120z" fill="currentColor" /></svg></div>
                         <h3>Calma Mental</h3>
                         <p>Aprende a gestionar el "runrún" de la ansiedad y a dirigir tu atención hacia lo que de verdad importa.</p>
                     </div>
-                    <div class="info-card">
+                    <div class="info-card card">
                         <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M305 151.1L320 171.8L335 151.1C360 116.5 400.2 96 442.9 96C516.4 96 576 155.6 576 229.1L576 231.7C576 343.9 436.1 474.2 363.1 529.9C350.7 539.3 335.5 544 320 544C304.5 544 289.2 539.4 276.9 529.9C203.9 474.2 64 343.9 64 231.7L64 229.1C64 155.6 123.6 96 197.1 96C239.8 96 280 116.5 305 151.1z" fill="currentColor" /></svg></div>
                         <h3>Relaciones Sanas</h3>
                         <p>Construye conexiones más auténticas y seguras con tu pareja, familia y amigos.</p>
@@ -216,17 +178,17 @@
                     <h2 class="section-title">No buscaremos problemas en tu pasado, construiremos soluciones para tu futuro</h2>
                 </div>
                 <div class="grid-3">
-                    <div class="info-card">
+                    <div class="info-card card">
                         <div class="icon-wrapper text-primary"><span class="icon-slot"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M543.9 251.4c0-1.1 .1-2.2 .1-3.4c0-48.6-39.4-88-88-88l-40 0H320l-16 0 0 0v16 72c0 22.1-17.9 40-40 40s-40-17.9-40-40V128h.4c4-36 34.5-64 71.6-64H408c2.8 0 5.6 .2 8.3 .5l40.1-40.1c21.9-21.9 57.3-21.9 79.2 0l78.1 78.1c21.9 21.9 21.9 57.3 0 79.2l-69.7 69.7zM192 128V248c0 39.8 32.2 72 72 72s72-32.2 72-72V192h80l40 0c30.9 0 56 25.1 56 56c0 27.2-19.4 49.9-45.2 55c8.2 8.6 13.2 20.2 13.2 33c0 26.5-21.5 48-48 48h-2.7c1.8 5 2.7 10.4 2.7 16c0 26.5-21.5 48-48 48H224c-.9 0-1.8 0-2.7-.1l-37.7 37.7c-21.9 21.9-57.3 21.9-79.2 0L26.3 407.6c-21.9-21.9-21.9-57.3 0-79.2L96 258.7V224c0-53 43-96 96-96z" /></svg></span></div>
                         <h3>Terapia Colaborativa</h3>
                         <p>Tú eres el experto/a en tu vida. Mi trabajo no es darte consejos, sino crear un diálogo donde tus propias fortalezas y soluciones salgan a la luz.</p>
                     </div>
-                    <div class="info-card">
+                    <div class="info-card card">
                         <div class="icon-wrapper text-primary"><span class="icon-slot"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M192 384L88.5 384C63.6 384 48.3 356.9 61.1 335.5L114 247.3C122.7 232.8 138.3 224 155.2 224L250.2 224C326.3 95.1 439.8 88.6 515.7 99.7C528.5 101.6 538.5 111.6 540.3 124.3C551.4 200.2 544.9 313.7 416 389.8L416 484.8C416 501.7 407.2 517.3 392.7 526L304.5 578.9C283.2 591.7 256 576.3 256 551.5L256 448C256 412.7 227.3 384 192 384L191.9 384zM464 224C464 197.5 442.5 176 416 176C389.5 176 368 197.5 368 224C368 250.5 389.5 272 416 272C442.5 272 464 250.5 464 224z" /></svg></span></div>
                         <h3>Enfoque Breve y Eficaz</h3>
                         <p>Nos centramos en el cambio desde el minuto cero. El objetivo es que notes mejoras y adquieras herramientas prácticas en pocas sesiones (la media es de 6-8).</p>
                     </div>
-                    <div class="info-card">
+                    <div class="info-card card">
                         <div class="icon-wrapper text-primary"><span class="icon-slot"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M420.9 448C428.2 425.7 442.8 405.5 459.3 388.1C492 353.7 512 307.2 512 256C512 150 426 64 320 64C214 64 128 150 128 256C128 307.2 148 353.7 180.7 388.1C197.2 405.5 211.9 425.7 219.1 448L420.8 448zM416 496L224 496L224 512C224 556.2 259.8 592 304 592L336 592C380.2 592 416 556.2 416 512L416 496zM312 176C272.2 176 240 208.2 240 248C240 261.3 229.3 272 216 272C202.7 272 192 261.3 192 248C192 181.7 245.7 128 312 128C325.3 128 336 138.7 336 152C336 165.3 325.3 176 312 176z" /></svg></span></div>
                         <h3>Centrada en Recursos</h3>
                         <p>No existe la "resistencia". Creo firmemente que tienes todos los recursos que necesitas. Juntos, los descubriremos y los pondremos a trabajar para ti.</p>
@@ -260,14 +222,14 @@
                 </div>
                 <div class="grid-2">
                     <a href="terapia-pareja.html">
-                        <div class="specialization-card">
+                        <div class="specialization-card card">
                             <h3>Terapia de Pareja</h3>
                             <p>Un espacio para mejorar la comunicación, resolver conflictos y recuperar la intimidad perdida.</p>
                             <p><span class="link-more">Saber más →</span></p>
                         </div>
                     </a>
                     <a href="terapia-online.html">
-                        <div class="specialization-card">
+                        <div class="specialization-card card">
                             <h3>Terapia Online</h3>
                             <p>La misma eficacia y cercanía, con la flexibilidad que necesitas y desde la comodidad de tu hogar.</p>
                             <p><span class="link-more">Saber más →</span></p>
@@ -286,7 +248,7 @@
                     <p>Mi compromiso es con una terapia honesta y breve. No uso bonos porque no quiero que pagues por más sesiones de las que realmente necesitas. La transparencia es parte del proceso de confianza.</p>
                 </div>
                 <div class="tarifas-grid">
-                    <div class="tarifa-card">
+                    <div class="tarifa-card pricing-card card">
                         <h3>Sesión Online</h3>
                         <div class="price">55€</div>
                         <p class="duration">55 minutos</p>
@@ -303,7 +265,7 @@
                         </ul>
                         <a href="terapia-online.html" class="btn btn-secondary">Saber Más</a>
                     </div>
-                    <div class="tarifa-card highlight">
+                    <div class="tarifa-card pricing-card card highlight">
                         <h3>Sesión Presencial</h3>
                         <div class="price">65€</div>
                         <p class="duration">55 minutos | En mi consulta de Roses</p>
@@ -320,7 +282,7 @@
                         </ul>
                         <a href="https://wa.me/34621372442?text=Hola%20Javi,%20quiero%20pedir%20cita%20para%20una%20sesión%20presencial." target="_blank" rel="noopener" class="btn btn-primary">Pedir Cita Presencial</a>
                     </div>
-                    <div class="tarifa-card">
+                    <div class="tarifa-card pricing-card card">
                         <h3>Sesión de Pareja</h3>
                         <div class="price">70€</div>
                         <p class="duration">Hasta 90 minutos</p>
@@ -348,7 +310,7 @@
                     <p class="section-subtitle">LA OPINIÓN DE MIS CLIENTES</p>
                     <h2 class="section-title">Confianza construida sesión a sesión</h2>
                 </div>
-                <div class="testimonial-slider-container">
+                <div class="testimonial-slider-container carousel">
                     <div class="testimonial-slider">
                         <div class="testimonial-slide">
                             <div class="testimonial-card">

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -17,16 +17,14 @@
     <link rel="preload" href="/fonts/inter-v20-latin-regular.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/inter-v20-latin-600.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/inter-v20-latin-700.woff2" as="font" type="font/woff2" crossorigin>
-    <style>
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-regular.woff2') format('woff2');font-weight:400;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-600.woff2') format('woff2');font-weight:600;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-700.woff2') format('woff2');font-weight:700;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    </style>
-    <link rel="stylesheet" href="/css/base.css">
-    <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
 
-    <link rel="preload" href="css/legal-styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="css/legal-styles.css"></noscript>
+    <link rel="stylesheet" href="/css/base.css">
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/hero.css">
+    <link rel="stylesheet" href="/css/space.css">
+    <link rel="stylesheet" href="/css/testimonios.css">
+    <link rel="stylesheet" href="/css/mapa.css">
+    <link rel="stylesheet" href="/css/legal-styles.css">
 
     <script type="application/ld+json">
     {

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -16,17 +16,15 @@
     <!-- Fonts Inter (self-hosted per millorar velocitat) -->
     <link rel="preload" href="/fonts/inter-v20-latin-regular.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/inter-v20-latin-600.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="/fonts/inter-v20-latin-700.woff2" as="font" type="font/woff2" crossorigin> 
-    <style>
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-regular.woff2') format('woff2');font-weight:400;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-600.woff2') format('woff2');font-weight:600;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-700.woff2') format('woff2');font-weight:700;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    </style>
-    <link rel="stylesheet" href="/css/base.css">
-    <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
+    <link rel="preload" href="/fonts/inter-v20-latin-700.woff2" as="font" type="font/woff2" crossorigin>
 
-    <link rel="preload" href="css/legal-styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="css/legal-styles.css"></noscript>
+    <link rel="stylesheet" href="/css/base.css">
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/hero.css">
+    <link rel="stylesheet" href="/css/space.css">
+    <link rel="stylesheet" href="/css/testimonios.css">
+    <link rel="stylesheet" href="/css/mapa.css">
+    <link rel="stylesheet" href="/css/legal-styles.css">
 
     <script type="application/ld+json">
     {

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -31,53 +31,15 @@
     <!-- Fonts Inter (self-hosted per millorar velocitat) -->
     <link rel="preload" href="/fonts/inter-v20-latin-regular.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/inter-v20-latin-600.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="/fonts/inter-v20-latin-700.woff2" as="font" type="font/woff2" crossorigin> 
-    <style>
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-regular.woff2') format('woff2');font-weight:400;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-600.woff2') format('woff2');font-weight:600;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-700.woff2') format('woff2');font-weight:700;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    </style>
+    <link rel="preload" href="/fonts/inter-v20-latin-700.woff2" as="font" type="font/woff2" crossorigin>
 
-    <!-- CSS CRÍTICO - Previene CLS -->
-    <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-        background-color: #F9F9F7;
-        color: #4A5568;
-        line-height: 1.6;
-    }
-    .header {
-        background: rgba(249, 249, 247, 0.75);
-        backdrop-filter: blur(12px);
-        position: fixed;
-        width: 100%;
-        z-index: 100;
-        height: 90px;
-    }
-    .hero {
-        padding-top: 8rem;
-    }
-    .logo-container {
-        width: 240px;
-        height: 70px;
-    }
-    @media (max-width: 768px) {
-        .logo-container {
-            width: 180px;
-            height: 50px;
-        }
-        .hero {
-            padding-top: 8rem;
-        }
-    }
-    </style>
-    
     <link rel="stylesheet" href="/css/base.css">
-    <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
-
-    <link rel="preload" href="css/terapia-online.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="css/terapia-online.css"></noscript>
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/hero.css">
+    <link rel="stylesheet" href="/css/space.css">
+    <link rel="stylesheet" href="/css/testimonios.css">
+    <link rel="stylesheet" href="/css/mapa.css">
+    <link rel="stylesheet" href="/css/terapia-online.css">
 
     
     <script type="application/ld+json">
@@ -189,17 +151,17 @@
                     <h2 class="section-title">La Terapia Breve es la aliada perfecta del formato online</h2>
                 </div>
                 <div class="grid-3">
-                    <div class="info-card">
+                    <div class="info-card card">
                         <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M512 320C512 214 426 128 320 128C214 128 128 214 128 320C128 426 214 512 320 512C426 512 512 426 512 320zM64 320C64 178.6 178.6 64 320 64C461.4 64 576 178.6 576 320C576 461.4 461.4 576 320 576C178.6 576 64 461.4 64 320zM320 400C364.2 400 400 364.2 400 320C400 275.8 364.2 240 320 240C275.8 240 240 275.8 240 320C240 364.2 275.8 400 320 400zM320 176C399.5 176 464 240.5 464 320C464 399.5 399.5 464 320 464C240.5 464 176 399.5 176 320C176 240.5 240.5 176 320 176zM288 320C288 302.3 302.3 288 320 288C337.7 288 352 302.3 352 320C352 337.7 337.7 352 320 352C302.3 352 288 337.7 288 320z" fill="currentColor" /></svg></div>
                         <h3>Enfocada en Soluciones</h3>
                         <p>No nos perdemos en el pasado. Buscamos activamente lo que ya funciona en tu vida y lo amplificamos. El cambio se construye sobre tus fortalezas.</p>
                     </div>
-                    <div class="info-card">
+                    <div class="info-card card">
                         <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M403.7 107.1C392.1 96 375 92.9 360.3 99.2C345.6 105.5 336 120 336 136L336 272.3L163.7 107.2C152.1 96 135 92.9 120.3 99.2C105.6 105.5 96 120 96 136L96 504C96 520 105.6 534.5 120.3 540.8C135 547.1 152.1 544 163.7 532.9L336 367.7L336 504C336 520 345.6 534.5 360.3 540.8C375 547.1 392.1 544 403.7 532.9L595.7 348.9C603.6 341.4 608 330.9 608 320C608 309.1 603.5 298.7 595.7 291.1L403.7 107.1z" fill="currentColor" /></svg></div>
                         <h3>Máxima Eficiencia</h3>
                         <p>Al ser un modelo tan focalizado, a menudo se requieren menos sesiones. Cada minuto de la sesión online se aprovecha para construir el cambio.</p>
                     </div>
-                    <div class="info-card">
+                    <div class="info-card card">
                         <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M192 256c61.9 0 112-50.1 112-112S253.9 32 192 32 80 82.1 80 144s50.1 112 112 112zm76.8 32h-8.3c-20.8 10-43.9 16-68.5 16s-47.6-6-68.5-16h-8.3C51.6 288 0 339.6 0 403.2V432c0 26.5 21.5 48 48 48h288c26.5 0 48-21.5 48-48v-28.8c0-63.6-51.6-115.2-115.2-115.2zM480 256c53 0 96-43 96-96s-43-96-96-96-96 43-96 96 43 96 96 96zm48 32h-3.8c-13.9 4.8-28.6 8-44.2 8s-30.3-3.2-44.2-8H432c-20.4 0-39.2 5.9-55.7 15.4 24.4 26.3 39.7 61.2 39.7 99.8v38.4c0 2.2-.5 4.3-.6 6.4H592c26.5 0 48-21.5 48-48 0-61.9-50.1-112-112-112z" fill="currentColor" /></svg></div>
                         <h3>Tú eres el/la experto/a</h3>
                         <p>Mi rol no es darte respuestas, sino hacer las preguntas adecuadas para que tú encuentres las tuyas. Es un trabajo en equipo, 100% colaborativo.</p>
@@ -234,17 +196,17 @@
                     <h2 class="section-title">Un proceso simple para empezar</h2>
                 </div>
                 <div class="grid-3">
-                    <div class="content-card">
+                    <div class="content-card card">
                         <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M256 32C114.6 32 0 125.1 0 240c0 49.6 21.4 95 57 130.7C44.5 421.1 2.7 466 2.2 466.5c-2.2 2.3-2.8 5.7-1.5 8.7S4.8 480 8 480c66.3 0 116-31.8 140.6-51.4 32.7 12.3 69 19.4 107.4 19.4 141.4 0 256-93.1 256-208S397.4 32 256 32zM128 272c-17.7 0-32-14.3-32-32s14.3-32 32-32 32 14.3 32 32-14.3 32-32 32zm128 0c-17.7 0-32-14.3-32-32s14.3-32 32-32 32 14.3 32 32-14.3 32-32 32zm128 0c-17.7 0-32-14.3-32-32s14.3-32 32-32 32 14.3 32 32-14.3 32-32 32z" fill="currentColor" /></svg></div>
                         <h3>1. Contacto Inicial</h3>
                         <p>Me escribes por WhatsApp o email. Te explico cómo trabajo y resolvemos tus dudas iniciales.</p>
                     </div>
-                    <div class="content-card">
+                    <div class="content-card card">
                         <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M416 64C433.7 64 448 78.3 448 96L448 128L480 128C515.3 128 544 156.7 544 192L544 480C544 515.3 515.3 544 480 544L160 544C124.7 544 96 515.3 96 480L96 192C96 156.7 124.7 128 160 128L192 128L192 96C192 78.3 206.3 64 224 64C241.7 64 256 78.3 256 96L256 128L384 128L384 96C384 78.3 398.3 64 416 64zM438 225.7C427.3 217.9 412.3 220.3 404.5 231L285.1 395.2L233 343.1C223.6 333.7 208.4 333.7 199.1 343.1C189.8 352.5 189.7 367.7 199.1 377L271.1 449C276.1 454 283 456.5 289.9 456C296.8 455.5 303.3 451.9 307.4 446.2L443.3 259.2C451.1 248.5 448.7 233.5 438 225.7z" fill="currentColor" /></svg></div>
                         <h3>2. Primera Sesión</h3>
                         <p>Acordamos día y hora. Te envío el enlace de la videollamada (Google Meet). Nos conocemos y definimos los objetivos.</p>
                     </div>
-                    <div class="content-card">
+                    <div class="content-card card">
                         <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M416 320h-96c-17.6 0-32-14.4-32-32s14.4-32 32-32h96s96-107 96-160-43-96-96-96-96 43-96 96c0 25.5 22.2 63.4 45.3 96H320c-52.9 0-96 43.1-96 96s43.1 96 96 96h96c17.6 0 32 14.4 32 32s-14.4 32-32 32H185.5c-16 24.8-33.8 47.7-47.3 64H416c52.9 0 96-43.1 96-96s-43.1-96-96-96zm0-256c17.7 0 32 14.3 32 32s-14.3 32-32 32-32-14.3-32-32 14.3-32 32-32zM96 256c-53 0-96 43-96 96s96 160 96 160 96-107 96-160-43-96-96-96zm0 128c-17.7 0-32-14.3-32-32s14.3-32 32-32 32 14.3 32 32-14.3 32-32 32z" fill="currentColor" /></svg></div>
                         <h3>3. Tu Proceso</h3>
                         <p>Trabajamos juntos, sesión a sesión, con herramientas prácticas y cambios reales. Tú marcas el ritmo.</p>
@@ -261,17 +223,17 @@
                     <h2 class="section-title">La terapia se adapta a ti, no al revés</h2>
                 </div>
                 <div class="grid-3">
-                    <div class="info-card">
+                    <div class="info-card card">
                         <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M280.37 148.26L96 300.11V464a16 16 0 0 0 16 16l112.06-.29a16 16 0 0 0 15.92-16V368a16 16 0 0 1 16-16h64a16 16 0 0 1 16 16v95.64a16 16 0 0 0 16 16.05L464 480a16 16 0 0 0 16-16V300L295.67 148.26a12.19 12.19 0 0 0-15.3 0zM571.6 251.47L488 182.56V44.05a12 12 0 0 0-12-12h-56a12 12 0 0 0-12 12v72.61L318.47 43a48 48 0 0 0-61 0L4.34 251.47a12 12 0 0 0-1.6 16.9l25.5 31A12 12 0 0 0 45.15 301l235.22-193.74a12.19 12.19 0 0 1 15.3 0L530.9 301a12 12 0 0 0 16.9-1.6l25.5-31a12 12 0 0 0-1.7-16.93z" fill="currentColor" /></svg></div>
                         <h3>Desde tu espacio seguro</h3>
                         <p>Tu casa, tu ambiente, tu comodidad. No necesitas desplazarte ni perder tiempo en la sala de espera. La terapia llega a ti, estés donde estés.</p>
                     </div>
-                    <div class="info-card">
+                    <div class="info-card card">
                         <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M0 464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V192H0v272zm320-196c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zM192 268c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zM64 268c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H76c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H76c-6.6 0-12-5.4-12-12v-40zM400 64h-48V16c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v48H160V16c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v48H48C21.5 64 0 85.5 0 112v48h448v-48c0-26.5-21.5-48-48-48z" fill="currentColor" /></svg></div>
                         <h3>Horarios que se ajustan a tu vida</h3>
                         <p>Mañanas, tardes, incluso fines de semana si es necesario. Nos adaptamos a tu agenda laboral, familiar o personal. Sin rigidez, con flexibilidad real.</p>
                     </div>
-                    <div class="info-card">
+                    <div class="info-card card">
                         <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M415.9 344L225 344C227.9 408.5 242.2 467.9 262.5 511.4C273.9 535.9 286.2 553.2 297.6 563.8C308.8 574.3 316.5 576 320.5 576C324.5 576 332.2 574.3 343.4 563.8C354.8 553.2 367.1 535.8 378.5 511.4C398.8 467.9 413.1 408.5 416 344zM224.9 296L415.8 296C413 231.5 398.7 172.1 378.4 128.6C367 104.2 354.7 86.8 343.3 76.2C332.1 65.7 324.4 64 320.4 64C316.4 64 308.7 65.7 297.5 76.2C286.1 86.8 273.8 104.2 262.4 128.6C242.1 172.1 227.8 231.5 224.9 296zM176.9 296C180.4 210.4 202.5 130.9 234.8 78.7C142.7 111.3 74.9 195.2 65.5 296L176.9 296zM65.5 344C74.9 444.8 142.7 528.7 234.8 561.3C202.5 509.1 180.4 429.6 176.9 344L65.5 344zM463.9 344C460.4 429.6 438.3 509.1 406 561.3C498.1 528.6 565.9 444.8 575.3 344L463.9 344zM575.3 296C565.9 195.2 498.1 111.3 406 78.7C438.3 130.9 460.4 210.4 463.9 296L575.3 296z" fill="currentColor" /></svg></div>
                         <h3>Sin barreras geográficas</h3>
                         <p>Vives lejos de Roses, viajas frecuentemente o simplemente prefieres la comodidad del online. La distancia física ya no es un obstáculo para cuidar de tu salud mental.</p>
@@ -287,7 +249,7 @@
                     <p class="section-subtitle">LA OPINIÓN DE MIS CLIENTES</p>
                     <h2 class="section-title">Confianza construida sesión a sesión</h2>
                 </div>
-                <div class="testimonial-slider-container">
+                <div class="testimonial-slider-container carousel">
                     <div class="testimonial-slider">
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
@@ -429,7 +391,7 @@
                     <h2 class="section-title">Tarifa Terapia Online</h2>
                     <p>Mi compromiso es con una terapia honesta y breve. No uso bonos porque no quiero que pagues por más sesiones de las que realmente necesitas.</p>
                 </div>
-                <div class="tarifa-card highlight">
+                <div class="tarifa-card pricing-card card highlight">
                     <h3>Sesión Online</h3>
                     <div class="price">55€</div>
                     <p class="duration">55 minutos</p>

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -31,53 +31,15 @@
     <!-- Fonts Inter (self-hosted per millorar velocitat) -->
     <link rel="preload" href="/fonts/inter-v20-latin-regular.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/inter-v20-latin-600.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="/fonts/inter-v20-latin-700.woff2" as="font" type="font/woff2" crossorigin> 
-    <style>
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-regular.woff2') format('woff2');font-weight:400;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-600.woff2') format('woff2');font-weight:600;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    @font-face{font-family:'Inter';src:url('/fonts/inter-v20-latin-700.woff2') format('woff2');font-weight:700;font-style:normal;font-display:swap;ascent-override:90%;descent-override:22%;line-gap-override:0%;size-adjust:102%}
-    </style>
+    <link rel="preload" href="/fonts/inter-v20-latin-700.woff2" as="font" type="font/woff2" crossorigin>
 
-    <!-- CSS CRÍTICO - Previene CLS -->
-    <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-        background-color: #F9F9F7;
-        color: #4A5568;
-        line-height: 1.6;
-    }
-    .header {
-        background: rgba(249, 249, 247, 0.75);
-        backdrop-filter: blur(12px);
-        position: fixed;
-        width: 100%;
-        z-index: 100;
-        height: 90px;
-    }
-    .hero {
-        padding-top: 8rem;
-    }
-    .logo-container {
-        width: 240px;
-        height: 70px;
-    }
-    @media (max-width: 768px) {
-        .logo-container {
-            width: 180px;
-            height: 50px;
-        }
-        .hero {
-            padding-top: 8rem;
-        }
-    }
-    </style>
-    
     <link rel="stylesheet" href="/css/base.css">
-    <!-- CSS carregat de forma asíncrona per no bloquejar renderitzat -->
-
-    <link rel="preload" href="css/terapia-pareja.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="css/terapia-pareja.css"></noscript>
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/hero.css">
+    <link rel="stylesheet" href="/css/space.css">
+    <link rel="stylesheet" href="/css/testimonios.css">
+    <link rel="stylesheet" href="/css/mapa.css">
+    <link rel="stylesheet" href="/css/terapia-pareja.css">
     
     
     <script type="application/ld+json">
@@ -189,12 +151,12 @@
                     <h2 class="section-title">Un Mapa Claro para Vuestra Relación</h2>
                 </div>
                 <div class="grid-2">
-                    <div class="content-card">
+                    <div class="content-card card">
                         <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M240 64C213.5 64 192 85.5 192 112L192 320C192 346.5 213.5 368 240 368L304 368C330.5 368 352 346.5 352 320L352 256L384 256C454.7 256 512 313.3 512 384C512 454.7 454.7 512 384 512L96 512C78.3 512 64 526.3 64 544C64 561.7 78.3 576 96 576L544 576C561.7 576 576 561.7 576 544C576 526.3 561.7 512 544 512L527.1 512C557.5 478 576 433.2 576 384C576 278 490 192 384 192L352 192L352 112C352 85.5 330.5 64 304 64L240 64zM184 416C170.7 416 160 426.7 160 440C160 453.3 170.7 464 184 464L360 464C373.3 464 384 453.3 384 440C384 426.7 373.3 416 360 416L184 416z" fill="currentColor" /></svg></div>
                         <h3>El Método Gottman: La Ciencia de las Parejas</h3>
                         <p>No trabajaremos con opiniones, sino con décadas de investigación científica. El Dr. John Gottman identificó los pilares que sostienen a las parejas felices. Aprenderemos a desactivar los "Cuatro Jinetes del Apocalipsis" (crítica, desprecio, actitud defensiva y evasión) y a construir una base sólida de amistad, admiración y propósito compartido.</p>
                     </div>
-                    <div class="content-card">
+                    <div class="content-card card">
                         <div class="icon-wrapper text-primary"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor"><path d="M488 192H336v56c0 39.7-32.3 72-72 72s-72-32.3-72-72V126.4l-64.9 39C107.8 176.9 96 197.8 96 220.2v47.3l-80 46.2C.7 322.5-4.6 342.1 4.3 357.4l80 138.6c8.8 15.3 28.4 20.5 43.7 11.7L231.4 448H368c35.3 0 64-28.7 64-64h16c17.7 0 32-14.3 32-32v-64h8c13.3 0 24-10.7 24-24v-48c0-13.3-10.7-24-24-24zm147.7-37.4L555.7 16C546.9.7 527.3-4.5 512 4.3L408.6 64H306.4c-12 0-23.7 3.4-33.9 9.7L239 94.6c-9.4 5.8-15 16.1-15 27.1V248c0 22.1 17.9 40 40 40s40-17.9 40-40v-88h184c30.9 0 56 25.1 56 56v28.5l80-46.2c15.3-8.9 20.5-28.4 11.7-43.7z" fill="currentColor" /></svg></div>
                         <h3>Terapia Sistémica Breve: Vuestras Soluciones</h3>
                         <p>Cada pareja es un mundo. No hay recetas mágicas. Mi papel es ayudaros a descubrir qué es lo que SÍ funciona entre vosotros (aunque ahora parezca poco) y a amplificarlo. Identificaremos los patrones que os bloquean y, juntos, diseñaremos pequeños cambios que generen grandes diferencias.</p>
@@ -247,7 +209,7 @@
                     <p class="section-subtitle">LA OPINIÓN DE MIS CLIENTES</p>
                     <h2 class="section-title">Confianza construida sesión a sesión</h2>
                 </div>
-                <div class="testimonial-slider-container">
+                <div class="testimonial-slider-container carousel">
                     <div class="testimonial-slider">
                         <div class="testimonial-slide">
                             <div class="testimonial-card">
@@ -389,7 +351,7 @@
                     <h2 class="section-title">Tarifa Terapia de Pareja</h2>
                     <p>Mi compromiso es con una terapia honesta y breve. No uso bonos porque no quiero que paguéis por más sesiones de las que realmente necesitáis.</p>
                 </div>
-                <div class="tarifa-card highlight">
+                <div class="tarifa-card pricing-card card highlight">
                     <h3>Sesión de Pareja</h3>
                     <div class="price">70€</div>
                     <p class="duration">Hasta 90 minutos | Presencial u Online</p>


### PR DESCRIPTION
## Summary
- Load the shared CSS bundles for every page directly in the head alongside Inter font preloads to avoid late style application.
- Add reusable `.card`/`.pricing-card` layout guardrails plus carousel and hero media placeholders to keep desktop heights stable.

## Testing
- Not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68e3b8e688dc832583fb9d35fbb38462