### PR TITLE
chore: remove CLS debug helper (PerformanceObserver)

### DIFF
--- a/codigo-deontologico.html
+++ b/codigo-deontologico.html
@@ -214,31 +214,6 @@
         </div>
     </div>
 
-    <script>
-    (function(){
-      if(!('PerformanceObserver' in window) || !('URLSearchParams' in window)) return;
-      const params = new URLSearchParams(window.location.search);
-      if(params.get('cls-debug') !== '1') return;
-      try {
-        const po = new PerformanceObserver((list)=>{
-          for (const entry of list.getEntries()){
-            if (entry.hadRecentInput) continue;
-            entry.sources?.forEach((source)=>{
-              const el = source.node;
-              if (!(el instanceof Element)) return;
-              el.style.outline = '2px solid rgba(255,0,0,.85)';
-              el.style.outlineOffset = '2px';
-              console.warn('CLS source:', el, 'value:', entry.value, entry);
-            });
-          }
-        });
-        po.observe({type:'layout-shift', buffered:true});
-      } catch (error) {
-        console.error('CLS debug observer failed', error);
-      }
-    })();
-    </script>
-
     <script src="/js/main.js" defer></script>
     <script src="/js/cookies.js" defer></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -597,31 +597,6 @@
         </div>
     </div>
 
-    <script>
-    (function(){
-      if(!('PerformanceObserver' in window) || !('URLSearchParams' in window)) return;
-      const params = new URLSearchParams(window.location.search);
-      if(params.get('cls-debug') !== '1') return;
-      try {
-        const po = new PerformanceObserver((list)=>{
-          for (const entry of list.getEntries()){
-            if (entry.hadRecentInput) continue;
-            entry.sources?.forEach((source)=>{
-              const el = source.node;
-              if (!(el instanceof Element)) return;
-              el.style.outline = '2px solid rgba(255,0,0,.85)';
-              el.style.outlineOffset = '2px';
-              console.warn('CLS source:', el, 'value:', entry.value, entry);
-            });
-          }
-        });
-        po.observe({type:'layout-shift', buffered:true});
-      } catch (error) {
-        console.error('CLS debug observer failed', error);
-      }
-    })();
-    </script>
-
     <script src="/js/main.js" defer></script>
     <script src="/js/cookies.js" defer></script>
 </body>

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -525,31 +525,6 @@
         </div>
     </div>
 
-    <script>
-    (function(){
-      if(!('PerformanceObserver' in window) || !('URLSearchParams' in window)) return;
-      const params = new URLSearchParams(window.location.search);
-      if(params.get('cls-debug') !== '1') return;
-      try {
-        const po = new PerformanceObserver((list)=>{
-          for (const entry of list.getEntries()){
-            if (entry.hadRecentInput) continue;
-            entry.sources?.forEach((source)=>{
-              const el = source.node;
-              if (!(el instanceof Element)) return;
-              el.style.outline = '2px solid rgba(255,0,0,.85)';
-              el.style.outlineOffset = '2px';
-              console.warn('CLS source:', el, 'value:', entry.value, entry);
-            });
-          }
-        });
-        po.observe({type:'layout-shift', buffered:true});
-      } catch (error) {
-        console.error('CLS debug observer failed', error);
-      }
-    })();
-    </script>
-
     <script src="/js/main.js" defer></script>
     <script src="/js/cookies.js" defer></script>
 </body>

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -496,31 +496,6 @@
         </div>
     </div>
 
-    <script>
-    (function(){
-      if(!('PerformanceObserver' in window) || !('URLSearchParams' in window)) return;
-      const params = new URLSearchParams(window.location.search);
-      if(params.get('cls-debug') !== '1') return;
-      try {
-        const po = new PerformanceObserver((list)=>{
-          for (const entry of list.getEntries()){
-            if (entry.hadRecentInput) continue;
-            entry.sources?.forEach((source)=>{
-              const el = source.node;
-              if (!(el instanceof Element)) return;
-              el.style.outline = '2px solid rgba(255,0,0,.85)';
-              el.style.outlineOffset = '2px';
-              console.warn('CLS source:', el, 'value:', entry.value, entry);
-            });
-          }
-        });
-        po.observe({type:'layout-shift', buffered:true});
-      } catch (error) {
-        console.error('CLS debug observer failed', error);
-      }
-    })();
-    </script>
-
     <script src="/js/main.js" defer></script>
     <script src="/js/cookies.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- eliminados los bloques de depuración de CLS basados en `PerformanceObserver` de todas las plantillas afectadas
- mantenida intacta la carga de los scripts funcionales `main.js` y `cookies.js`

## Verification
- `rg "layout-shift"` (sin coincidencias)
- `rg "cls-debug"` (sin coincidencias)
- Lighthouse móvil y escritorio (CLS ≈ 0) – no disponible en este entorno, se recomienda ejecutar en local

------
https://chatgpt.com/codex/tasks/task_e_68e418eec6fc8325836085beafd5a574