### PR TITLE
UI — Iconos más grandes en cards (solo CSS)

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -339,3 +339,14 @@ section#especializacion .grid-2 > a {
         max-width: 100%;
     }
 }
+
+/* Iconos en cards de contenido (no footer, no estrellas) */
+main .section .card .icon,
+main .specialization-card .icon,
+main .tarifa-card .icon{
+  width:28px; height:28px; vertical-align:middle;
+}
+/* Salvaguardas explícitas */
+footer .icon,
+.star-rating .icon, .star-rating svg, .star-rating img{ width:inherit; height:inherit; }
+


### PR DESCRIPTION
## Summary
- Increase the displayed size of icons within content, specialization, and tarifa cards to improve legibility.
- Add explicit safeguards to keep footer and star-rating icons at their inherited dimensions.

## Testing
- Not run (not requested).

------
https://chatgpt.com/codex/tasks/task_e_68e43497de888325b7a6ca9a7e07d6da