### PR TITLE
Adjust card icon sizing and alignment

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -158,6 +158,58 @@ section#especializacion .grid-2 > a {
     font-size: initial;
 }
 
+/* === Iconos en cards de contenido === */
+/* Base: 30px para cards genéricas (excluye tarifas) */
+
+.section .card:not(.tarifa-card) .icon,
+.specialization-card .icon,
+.value-card .icon,
+.benefit-card .icon,
+.icon-wrapper > .icon {
+    width: 30px;
+    height: 30px;
+    vertical-align: middle;
+}
+
+/* Forzar también los tres iconos de "Un enfoque diferente" (home) */
+#como-trabajo .card .icon {
+    width: 30px;
+    height: 30px;
+}
+
+#como-trabajo .icon-slot {
+    width: 30px;
+    height: 30px;
+    flex: 0 0 30px;
+}
+
+/* Mantener tarifas como están (checks) */
+.tarifa-card .icon,
+.tarifa-card .icon img,
+.tarifa-card .icon svg {
+    width: inherit;
+    height: inherit;
+}
+
+/* === Centrado de iconos en secciones específicas === */
+/* Parejas → "Un enfoque científico y colaborativo" */
+#metodo .card .icon {
+    display: block;
+    margin-inline: auto;
+}
+
+/* Online → "Cómo funciona" */
+#como-funciona .card .icon {
+    display: block;
+    margin-inline: auto;
+}
+
+/* Guardarraíles: no tocar footer ni estrellas */
+footer .icon,
+.star-rating .icon,
+.star-rating svg,
+.star-rating img { width: inherit; height: inherit; }
+
 .specialization-card .icon-wrapper {
     color: var(--earth);
 }


### PR DESCRIPTION
## Summary
- enforce a 30px size for content card icons across pages while leaving pricing icons unchanged
- ensure home "Un enfoque diferente" icons respect the new sizing by updating their wrapper slot
- center icons within the pareja "Un enfoque científico y colaborativo" and online "Cómo funciona" sections

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e43bd5312483258d056ceca9d0a91b