### PR TITLE
UI — WhatsApp flotante: 44px móvil, 50px desktop (offsets 16/24)

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -395,17 +395,12 @@ footer .icon,
 
 .whatsapp-float {
     position: fixed;
-    width: 60px;
-    height: 60px;
-    bottom: 16px;
-    right: 16px;
     background-color: #25D366;
     color: white;
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 2rem;
     box-shadow: var(--shadow-md);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
     z-index: 99999;
@@ -505,8 +500,53 @@ footer .icon,
   margin-inline: auto;
 }
 
+:root{
+  --tap-target: 44px;
+  --fab-offset-mobile: 16px;   /* separación estándar móvil */
+  --fab-offset-desktop: 24px;  /* separación estándar desktop */
+  --wa-fab-mobile: 44px;       /* tamaño icono móvil */
+  --wa-fab-desktop: 50px;      /* tamaño icono desktop */
+}
+
+/* Contenedor FAB WhatsApp (ajusta a tus clases/ID reales) */
+#whatsapp-fab, .whatsapp-fab, .whatsapp-button, .whatsapp-float{
+  right: var(--fab-offset-mobile);
+  bottom: var(--fab-offset-mobile);
+  width: calc(var(--wa-fab-mobile) + 16px);   /* aire: 8px por lado */
+  height: calc(var(--wa-fab-mobile) + 16px);
+  display: grid;
+  place-items: center;
+  z-index: 9999;
+}
+#whatsapp-fab .icon, .whatsapp-fab .icon, .whatsapp-button .icon, .whatsapp-float .icon{
+  width: var(--wa-fab-mobile);
+  height: var(--wa-fab-mobile);
+  display: block;
+}
+
+/* Desktop: mayor icono y mayor separación a bordes */
+@media (min-width:1024px){
+  #whatsapp-fab, .whatsapp-fab, .whatsapp-button, .whatsapp-float{
+    right: var(--fab-offset-desktop);
+    bottom: var(--fab-offset-desktop);
+    width: calc(var(--wa-fab-desktop) + 16px);
+    height: calc(var(--wa-fab-desktop) + 16px);
+  }
+  #whatsapp-fab .icon, .whatsapp-fab .icon, .whatsapp-button .icon, .whatsapp-float .icon{
+    width: var(--wa-fab-desktop);
+    height: var(--wa-fab-desktop);
+  }
+}
+
+/* Safe areas iOS */
+@supports (padding: env(safe-area-inset-bottom)){
+  #whatsapp-fab, .whatsapp-fab, .whatsapp-button, .whatsapp-float{
+    margin-right: env(safe-area-inset-right);
+    margin-bottom: env(safe-area-inset-bottom);
+  }
+}
+
 /* Guardarraíles */
 footer .icon,
-.star-rating .icon,
-.star-rating svg,
-.star-rating img { width: inherit; height: inherit; }
+.star-rating .icon, .star-rating svg, .star-rating img{ width: inherit; height: inherit; }
+

--- a/index.html
+++ b/index.html
@@ -586,7 +586,7 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
 
-    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información." class="whatsapp-float" target="_blank" rel="noopener" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" decoding="async" width="28" height="28"></a>
+    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información." class="whatsapp-float" target="_blank" rel="noopener" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" decoding="async" width="50" height="50"></a>
 
     <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
         <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -514,7 +514,7 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
 
-    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." class="whatsapp-float" target="_blank" rel="noopener" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" decoding="async" width="28" height="28"></a>
+    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." class="whatsapp-float" target="_blank" rel="noopener" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" decoding="async" width="50" height="50"></a>
 
     <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
         <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -485,7 +485,7 @@
         <div class="footer-bottom"><p>&copy; 2025 Javi Cáceres Psicólogo. Todos los derechos reservados.</p></div>
     </footer>
 
-    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." class="whatsapp-float" target="_blank" rel="noopener" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" decoding="async" width="28" height="28"></a>
+    <a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." class="whatsapp-float" target="_blank" rel="noopener" aria-label="Contactar por WhatsApp"><img src="icons/whatsapp.svg" class="icon" alt="WhatsApp" decoding="async" width="50" height="50"></a>
 
     <div class="cookie-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
         <span id="cookie-title" class="visually-hidden">Preferencias de cookies</span>


### PR DESCRIPTION
## Summary
- ajusta el contenedor del botón flotante de WhatsApp para usar variables de tamaño y offsets diferenciados entre móvil y desktop
- mantiene los iconos del resto de la interfaz sin cambios gracias a guardarraíles explícitos
- actualiza los atributos de tamaño del icono flotante en las páginas afectadas

## Testing
- no se ejecutaron pruebas


------
https://chatgpt.com/codex/tasks/task_e_68e4455e0a9483259b9abd9a8931bb4e