### PR TITLE
Improve hamburger menu accessibility

### DIFF
--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -90,15 +90,15 @@
                 <li><a href="terapia-pareja.html">Terapia de Pareja</a></li>
                 <li><a href="terapia-online.html">Terapia Online</a></li>
             </ul>
-            <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
+            <button class="hamburger-menu" id="hamburger-btn" type="button" aria-label="Abrir menú" aria-expanded="false" aria-controls="main-nav">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false" width="24" height="24" fill="currentColor">
   <path d="M16 96a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32A16 16 0 0 1 16 96Zm0 160a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32a16 16 0 0 1-16-16Zm16 144a16 16 0 0 0 0 32h384a16 16 0 0 0 0-32H32Z" fill="currentColor" />
 </svg>
             </button>
         </nav>
     </header>
 
-    <div class="mobile-nav-panel" id="mobile-nav">
+    <div class="mobile-nav-panel" id="main-nav">
         <ul>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="terapia-pareja.html">Terapia de Pareja</a></li>

--- a/codigo-deontologico.html
+++ b/codigo-deontologico.html
@@ -90,15 +90,15 @@
                 <li><a href="terapia-pareja.html">Terapia de Pareja</a></li>
                 <li><a href="terapia-online.html">Terapia Online</a></li>
             </ul>
-            <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
+            <button class="hamburger-menu" id="hamburger-btn" type="button" aria-label="Abrir menú" aria-expanded="false" aria-controls="main-nav">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false" width="24" height="24" fill="currentColor">
   <path d="M16 96a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32A16 16 0 0 1 16 96Zm0 160a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32a16 16 0 0 1-16-16Zm16 144a16 16 0 0 0 0 32h384a16 16 0 0 0 0-32H32Z" fill="currentColor" />
 </svg>
             </button>
         </nav>
     </header>
 
-    <div class="mobile-nav-panel" id="mobile-nav">
+    <div class="mobile-nav-panel" id="main-nav">
         <ul>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="terapia-pareja.html">Terapia de Pareja</a></li>

--- a/css/common.css
+++ b/css/common.css
@@ -250,12 +250,6 @@ section#especializacion .grid-2 > a {
   }
 }
 
-/* Hamburguesa móvil: icono 24px y tap target 44px */
-.hamburger-menu{ width: var(--tap-target); height: var(--tap-target); display:grid; place-items:center; }
-.hamburger-menu .icon, .hamburger .icon, .hamburger-menu svg, .hamburger svg{
-  width: 24px; height: 24px; display:block;
-}
-
 /* Guardarraíles: NO tocar footer ni estrellas */
 footer .icon,
 .star-rating .icon, .star-rating svg, .star-rating img{ width: inherit; height: inherit; }
@@ -550,3 +544,32 @@ footer .icon,
 footer .icon,
 .star-rating .icon, .star-rating svg, .star-rating img{ width: inherit; height: inherit; }
 
+:root{ --tap-target: 44px; }
+
+/* Contenedor del botón: tamaño táctil y centrado del icono */
+.hamburger-menu{
+  width: var(--tap-target);
+  height: var(--tap-target);
+  display: grid;
+  place-items: center;
+  -webkit-tap-highlight-color: transparent;
+}
+.hamburger-menu .icon,
+.hamburger .icon,
+.hamburger-menu svg,
+.hamburger svg{
+  width: 24px;
+  height: 24px;
+  display: block;
+}
+
+/* Sin cambios de altura del header al abrir/cerrar */
+@media (min-width:1024px){
+  header.site-header{ min-height:72px; }
+}
+
+/* Accesibilidad: foco visible para teclado */
+.hamburger-menu:focus-visible{
+  outline: 2px solid #000;
+  outline-offset: 2px;
+}

--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
                 <li><a href="#tarifas">Tarifas</a></li>
                 <li><a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información." target="_blank" rel="noopener" class="btn btn-primary">Pedir Cita</a></li>
             </ul>
-            <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
+            <button class="hamburger-menu" id="hamburger-btn" type="button" aria-label="Abrir menú" aria-expanded="false" aria-controls="main-nav">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false" width="24" height="24" fill="currentColor">
   <path d="M16 96a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32A16 16 0 0 1 16 96Zm0 160a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32a16 16 0 0 1-16-16Zm16 144a16 16 0 0 0 0 32h384a16 16 0 0 0 0-32H32Z" fill="currentColor" />
 </svg>
@@ -116,7 +116,7 @@
         </nav>
     </header>
 
-    <div class="mobile-nav-panel" id="mobile-nav">
+    <div class="mobile-nav-panel" id="main-nav">
         <ul>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="terapia-pareja.html">Terapia de Pareja</a></li>

--- a/js/main.js
+++ b/js/main.js
@@ -57,13 +57,28 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Mobile menu toggle
     const hamburgerBtn = document.getElementById('hamburger-btn');
-    const mobileNav = document.getElementById('mobile-nav');
-    hamburgerBtn.addEventListener('click', () => {
-        mobileNav.classList.toggle('active');
-    });
-    mobileNav.querySelectorAll('a').forEach(link => {
-        link.addEventListener('click', () => mobileNav.classList.remove('active'));
-    });
+    const mobileNav = document.getElementById('main-nav');
+
+    if (hamburgerBtn && mobileNav) {
+        const setMenuA11yState = (isOpen) => {
+            hamburgerBtn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+            hamburgerBtn.setAttribute('aria-label', isOpen ? 'Cerrar menú' : 'Abrir menú');
+        };
+
+        hamburgerBtn.addEventListener('click', () => {
+            mobileNav.classList.toggle('active');
+            setMenuA11yState(mobileNav.classList.contains('active'));
+        });
+
+        mobileNav.querySelectorAll('a').forEach(link => {
+            link.addEventListener('click', () => {
+                mobileNav.classList.remove('active');
+                setMenuA11yState(false);
+            });
+        });
+
+        setMenuA11yState(mobileNav.classList.contains('active'));
+    }
     
     // FAQ accordion
     document.querySelectorAll('.faq-question').forEach(button => {

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -91,15 +91,15 @@
                 <li><a href="terapia-pareja.html">Terapia de Pareja</a></li>
                 <li><a href="terapia-online.html">Terapia Online</a></li>
             </ul>
-            <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
+            <button class="hamburger-menu" id="hamburger-btn" type="button" aria-label="Abrir menú" aria-expanded="false" aria-controls="main-nav">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false" width="24" height="24" fill="currentColor">
   <path d="M16 96a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32A16 16 0 0 1 16 96Zm0 160a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32a16 16 0 0 1-16-16Zm16 144a16 16 0 0 0 0 32h384a16 16 0 0 0 0-32H32Z" fill="currentColor" />
 </svg>
             </button>
         </nav>
     </header>
 
-    <div class="mobile-nav-panel" id="mobile-nav">
+    <div class="mobile-nav-panel" id="main-nav">
         <ul>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="terapia-pareja.html">Terapia de Pareja</a></li>

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -91,15 +91,15 @@
                 <li><a href="terapia-pareja.html">Terapia de Pareja</a></li>
                 <li><a href="terapia-online.html">Terapia Online</a></li>
             </ul>
-            <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
+            <button class="hamburger-menu" id="hamburger-btn" type="button" aria-label="Abrir menú" aria-expanded="false" aria-controls="main-nav">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false" width="24" height="24" fill="currentColor">
   <path d="M16 96a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32A16 16 0 0 1 16 96Zm0 160a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32a16 16 0 0 1-16-16Zm16 144a16 16 0 0 0 0 32h384a16 16 0 0 0 0-32H32Z" fill="currentColor" />
 </svg>
             </button>
         </nav>
     </header>
 
-    <div class="mobile-nav-panel" id="mobile-nav">
+    <div class="mobile-nav-panel" id="main-nav">
         <ul>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="terapia-pareja.html">Terapia de Pareja</a></li>

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -110,7 +110,7 @@
                 <li><a href="#tarifas">Tarifas</a></li>
                 <li><a href="https://wa.me/34621372442?text=Hola%20Javi,%20me%20gustaría%20pedir%20información%20sobre%20la%20terapia%20online." target="_blank" rel="noopener" class="btn btn-primary">Pedir Cita</a></li>
             </ul>
-            <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
+            <button class="hamburger-menu" id="hamburger-btn" type="button" aria-label="Abrir menú" aria-expanded="false" aria-controls="main-nav">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false" width="24" height="24" fill="currentColor">
   <path d="M16 96a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32A16 16 0 0 1 16 96Zm0 160a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32a16 16 0 0 1-16-16Zm16 144a16 16 0 0 0 0 32h384a16 16 0 0 0 0-32H32Z" fill="currentColor" />
 </svg>
@@ -118,7 +118,7 @@
         </nav>
     </header>
 
-    <div class="mobile-nav-panel" id="mobile-nav">
+    <div class="mobile-nav-panel" id="main-nav">
         <ul>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="terapia-pareja.html">Terapia de Pareja</a></li>

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -110,7 +110,7 @@
                 <li><a href="#tarifas">Tarifas</a></li>
                 <li><a href="https://wa.me/34621372442?text=Hola%20Javi,%20nos%20gustaría%20pedir%20información%20sobre%20la%20terapia%20de%20pareja." target="_blank" rel="noopener" class="btn btn-primary">Pedir Cita</a></li>
             </ul>
-            <button class="hamburger-menu" id="hamburger-btn" aria-label="Abrir menú">
+            <button class="hamburger-menu" id="hamburger-btn" type="button" aria-label="Abrir menú" aria-expanded="false" aria-controls="main-nav">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="icon" aria-hidden="true" focusable="false" width="24" height="24" fill="currentColor">
   <path d="M16 96a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32A16 16 0 0 1 16 96Zm0 160a16 16 0 0 1 16-16h384a16 16 0 0 1 0 32H32a16 16 0 0 1-16-16Zm16 144a16 16 0 0 0 0 32h384a16 16 0 0 0 0-32H32Z" fill="currentColor" />
 </svg>
@@ -118,7 +118,7 @@
         </nav>
     </header>
 
-    <div class="mobile-nav-panel" id="mobile-nav">
+    <div class="mobile-nav-panel" id="main-nav">
         <ul>
             <li><a href="index.html">Inicio</a></li>
             <li><a href="terapia-pareja.html">Terapia de Pareja</a></li>


### PR DESCRIPTION
## Summary
- normalize the hamburger button markup across pages with explicit type, aria attributes, and 24px icon sizing
- ensure the header toggle meets 44px tap target requirements and adds focus-visible styling without affecting layout
- update the mobile menu script to manage aria-expanded/aria-label states while targeting the renamed panel container

## Testing
- Manual verification


------
https://chatgpt.com/codex/tasks/task_e_68e447d033148325bac6f2d11f0502b8