### PR TITLE
Adjust header navigation responsiveness

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -573,3 +573,46 @@ footer .icon,
   outline: 2px solid #000;
   outline-offset: 2px;
 }
+
+/* Header responsive menu adjustments */
+.hamburger-menu {
+    display: grid;
+    place-items: center;
+    width: 44px;
+    height: 44px;
+}
+
+.nav-menu {
+    display: none;
+}
+
+@media (min-width: 992px) {
+    .hamburger-menu {
+        display: grid;
+    }
+
+    .nav-menu {
+        display: none;
+    }
+}
+
+@media (min-width: 1024px) {
+    .hamburger-menu {
+        display: none;
+    }
+
+    .nav-menu {
+        display: flex;
+        gap: 1.8rem;
+        align-items: center;
+    }
+    header.site-header {
+        min-height: 72px;
+    }
+}
+
+@media (max-width: 1023.98px) {
+    .nav-menu.is-open {
+        display: block;
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the hamburger button stays visible only on mobile viewports and show the horizontal nav menu from 1024px
- keep the header height stable on desktop and add support for a class-based mobile menu opening state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e44a8d86ac832597e91e664aa3a01f