### PR TITLE
Ajusta estilos de la landing de terapia online

### DIFF
--- a/css/terapia-online.css
+++ b/css/terapia-online.css
@@ -26,9 +26,6 @@
 }
 
 /* ===== Sección Sesiones justas y necesarias + Comparativa ===== */
-#sesiones-justas.section-muted{ background: var(--section-muted, #f8f9fa); }
-@media (min-width:1024px){ #sesiones-justas .section-header{ min-height:110px; } } /* anti-CLS */
-
 #sesiones-justas .sj-grid{ display:grid; gap:24px; grid-template-columns:1fr; }
 @media (min-width:768px){ #sesiones-justas .sj-grid{ grid-template-columns:1fr 1fr; } }
 
@@ -57,3 +54,27 @@
 }
 #faqs-online .faq[open] summary::after{ content:"▴"; }
 #faqs-online .faq .faq-body{ padding:.5rem 0 1rem; }
+
+/* ===== Alternancia de fondos (solo esta landing) ===== */
+.bg-sand { background: #F1F0EC; }
+.bg-porcelain { background: #F9F9F7; }
+
+/* Espaciado de títulos coherente con la web */
+.section-header h2 {
+  margin-bottom: var(--space-600, 1.25rem);
+}
+.section-header .section-subtitle {
+  margin-top: var(--space-200, .5rem);
+}
+
+/* “Enfoques: ¿qué cambia realmente?” centrado + aire */
+#sesiones-justas .compare > h3 {
+  text-align: center;
+  margin: var(--space-600, 1.25rem) 0 var(--space-500, 1rem);
+}
+
+/* Anti-CLS: cabeceras con altura estable en desktop */
+@media (min-width:1024px){
+  #sesiones-justas .section-header { min-height: 110px; }
+  #faqs-online .section-header { min-height: 90px; }
+}

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -144,7 +144,7 @@
         </section>
 
         <!-- 2. MENOS TIEMPO. MÁS FOCO - FONDO GRIS -->
-        <section class="section" style="background-color: var(--bg-lighter);">
+        <section class="section bg-sand">
             <div class="container">
                 <div class="section-header">
                     <p class="section-subtitle">MENOS TIEMPO. MÁS FOCO</p>
@@ -171,7 +171,7 @@
         </section>
 
         <!-- 3. EFICACIA DEMOSTRADA + SOBRE MÍ - FONDO BLANCO -->
-        <section class="section eficacia" id="quien-soy">
+        <section class="section eficacia bg-porcelain" id="quien-soy">
             <div class="container about-section">
                 <div style="text-align: center;">
                     <div class="media-slot">
@@ -188,7 +188,7 @@
             </div>
         </section>
 
-        <section id="sesiones-justas" class="section section-muted">
+        <section id="sesiones-justas" class="section bg-sand">
             <div class="container">
                 <header class="section-header">
                     <h2>Sesiones justas y necesarias</h2>
@@ -248,103 +248,8 @@
             </div>
         </section>
 
-        <section id="faqs-online" class="section">
-            <div class="container">
-                <header class="section-header">
-                    <h2>Preguntas frecuentes</h2>
-                </header>
-
-                <div class="faqs">
-                    <details class="faq">
-                        <summary>¿Cuánto dura la terapia?</summary>
-                        <div class="faq-body">
-                            <p>Hacemos las <strong>sesiones justas y necesarias</strong>. Revisamos el progreso alrededor de las <strong>8–10 sesiones</strong> para decidir juntos siguientes pasos. Si el cambio llega antes, cerramos antes; si necesitamos más, lo acordamos. No hay paquetes cerrados ni garantías de un número fijo.</p>
-                        </div>
-                    </details>
-
-                    <details class="faq">
-                        <summary>¿La terapia online es eficaz?</summary>
-                        <div class="faq-body">
-                            <p>Sí. Para muchos problemas (ansiedad, estrés, pareja, autoestima) la terapia online es tan eficaz como la presencial, con ventajas de accesibilidad y continuidad. Usamos un enfoque estructurado con tareas entre sesiones.</p>
-                        </div>
-                    </details>
-
-                    <details class="faq">
-                        <summary>¿Cómo son las sesiones?</summary>
-                        <div class="faq-body">
-                            <p>Sesiones de <strong>50–60 minutos</strong>, con objetivos concretos y acciones prácticas hasta la siguiente cita. Al inicio acordamos señales de progreso y ajustamos el ritmo a tu situación.</p>
-                        </div>
-                    </details>
-
-                    <details class="faq">
-                        <summary>¿Qué pasa si no noto avances?</summary>
-                        <div class="faq-body">
-                            <p>Revisamos estrategia y objetivos en la revisión (8–10). Si no hay cambios suficientes, planteamos ajustes o derivación responsable. La prioridad es la <strong>eficacia</strong>.</p>
-                        </div>
-                    </details>
-
-                    <details class="faq">
-                        <summary>Confidencialidad y privacidad</summary>
-                        <div class="faq-body">
-                            <p>Trabajo bajo normativa sanitaria vigente y código deontológico. Las sesiones son confidenciales y usamos plataformas seguras.</p>
-                        </div>
-                    </details>
-                </div>
-
-                <!-- JSON-LD para SEO (FAQPage) -->
-                <script type="application/ld+json">
-                {
-                  "@context": "https://schema.org",
-                  "@type": "FAQPage",
-                  "mainEntity": [
-                    {
-                      "@type": "Question",
-                      "name": "¿Cuánto dura la terapia?",
-                      "acceptedAnswer": {
-                        "@type": "Answer",
-                        "text": "Hacemos las sesiones justas y necesarias. Revisamos el progreso alrededor de las 8–10 sesiones para decidir juntos siguientes pasos. Si el cambio llega antes, cerramos antes; si necesitamos más, lo acordamos. No hay paquetes cerrados ni garantías de un número fijo."
-                      }
-                    },
-                    {
-                      "@type": "Question",
-                      "name": "¿La terapia online es eficaz?",
-                      "acceptedAnswer": {
-                        "@type": "Answer",
-                        "text": "Sí. Para muchos problemas la terapia online es tan eficaz como la presencial. Usamos un enfoque estructurado con objetivos y tareas entre sesiones."
-                      }
-                    },
-                    {
-                      "@type": "Question",
-                      "name": "¿Cómo son las sesiones?",
-                      "acceptedAnswer": {
-                        "@type": "Answer",
-                        "text": "Sesiones de 50–60 minutos, con objetivos claros y acciones prácticas hasta la siguiente cita. Ajustamos el ritmo a tu situación."
-                      }
-                    },
-                    {
-                      "@type": "Question",
-                      "name": "¿Qué pasa si no noto avances?",
-                      "acceptedAnswer": {
-                        "@type": "Answer",
-                        "text": "Revisamos estrategia y objetivos en la revisión (8–10). Si no hay avances suficientes, ajustamos el plan o valoramos derivación responsable. La prioridad es la eficacia."
-                      }
-                    },
-                    {
-                      "@type": "Question",
-                      "name": "Confidencialidad y privacidad",
-                      "acceptedAnswer": {
-                        "@type": "Answer",
-                        "text": "Trabajo bajo normativa sanitaria y código deontológico. Las sesiones son confidenciales y usamos plataformas seguras."
-                      }
-                    }
-                  ]
-                }
-                </script>
-            </div>
-        </section>
-
         <!-- 4. CÓMO FUNCIONA - FONDO GRIS -->
-        <section class="section" id="como-funciona" style="background-color: var(--bg-lighter);">
+        <section class="section bg-porcelain" id="como-funciona">
             <div class="container">
                 <div class="section-header">
                     <p class="section-subtitle">CÓMO FUNCIONA</p>
@@ -371,7 +276,7 @@
         </section>
 
         <!-- 5. FLEXIBILIDAD Y COMODIDAD - FONDO BLANCO -->
-        <section class="section">
+        <section class="section bg-sand">
             <div class="container">
                 <div class="section-header">
                     <p class="section-subtitle">FLEXIBILIDAD Y COMODIDAD</p>
@@ -398,7 +303,7 @@
         </section>
 
         <!-- 6. TESTIMONIOS MEJORADOS - FONDO GRIS -->
-        <section class="section testimonials-section" id="testimonios" style="background-color: var(--bg-lighter);" role="region" aria-label="Opiniones de clientes">
+        <section class="section testimonials-section bg-porcelain" id="testimonios" role="region" aria-label="Opiniones de clientes">
             <div class="container">
                 <div class="section-header">
                     <p class="section-subtitle">LA OPINIÓN DE MIS CLIENTES</p>
@@ -539,7 +444,7 @@
         </section>
 
         <!-- 7. TARIFAS - FONDO BLANCO -->
-        <section class="section" id="tarifas">
+        <section class="section bg-sand" id="tarifas">
             <div class="container" style="max-width: 550px;">
                 <div class="section-header">
                     <p class="section-subtitle">INVERSIÓN EN TU BIENESTAR</p>
@@ -569,45 +474,88 @@
             </div>
         </section>
 
-        <!-- 8. FAQ - FONDO GRIS -->
-        <section class="section" id="faq" style="background-color: var(--bg-lighter);">
+        <!-- 8. FAQ - FONDO CLARO -->
+        <section id="faqs-online" class="section bg-porcelain">
             <div class="container">
-                <div class="section-header">
-                    <p class="section-subtitle">RESOLVEMOS TUS DUDAS</p>
-                    <h2 class="section-title">Preguntas Frecuentes sobre Terapia Online</h2>
+                <header class="section-header">
+                    <h2>Preguntas frecuentes</h2>
+                </header>
+
+                <div class="faqs">
+                    <details class="faq">
+                        <summary>¿Cuánto dura la terapia?</summary>
+                        <div class="faq-body">
+                            <p>Hacemos las <strong>sesiones justas y necesarias</strong>. Revisamos el progreso alrededor de las <strong>8–10 sesiones</strong> como hito de chequeo (no es un tope ni una garantía). Si el cambio llega antes, cerramos antes; si hace falta más, lo acordamos.</p>
+                        </div>
+                    </details>
+
+                    <details class="faq">
+                        <summary>¿La terapia online es eficaz?</summary>
+                        <div class="faq-body">
+                            <p>Sí. Para muchos problemas (ansiedad, pareja, estrés, autoestima) la terapia online es tan eficaz como la presencial, con ventajas de accesibilidad y continuidad. Trabajamos con objetivos claros y tareas entre sesiones.</p>
+                        </div>
+                    </details>
+
+                    <details class="faq">
+                        <summary>¿Cómo empezamos?</summary>
+                        <div class="faq-body">
+                            <p>Primera sesión de evaluación y definición de objetivos observables. Acordamos señales de progreso y la frecuencia inicial (habitualmente semanal).</p>
+                        </div>
+                    </details>
+
+                    <details class="faq">
+                        <summary>¿Frecuencia y duración de cada sesión?</summary>
+                        <div class="faq-body">
+                            <p>Sesiones de <strong>50–60 minutos</strong>. La frecuencia se ajusta (semanal o quincenal) según objetivos y evolución.</p>
+                        </div>
+                    </details>
+
+                    <details class="faq">
+                        <summary>¿Qué problemas trabajo en terapia breve online?</summary>
+                        <div class="faq-body">
+                            <p>Ansiedad, estrés, problemas de pareja, autoestima, bloqueos puntuales y toma de decisiones, entre otros.</p>
+                        </div>
+                    </details>
+
+                    <details class="faq">
+                        <summary>¿Qué ocurre si no noto avances?</summary>
+                        <div class="faq-body">
+                            <p>Revisamos estrategia y objetivos en la revisión (8–10). Si no hay avances suficientes, ajustamos el plan o valoramos derivación responsable. La prioridad es la <strong>eficacia</strong>.</p>
+                        </div>
+                    </details>
+
+                    <details class="faq">
+                        <summary>Confidencialidad y privacidad</summary>
+                        <div class="faq-body">
+                            <p>Cumplo normativa sanitaria y código deontológico. Sesiones confidenciales y plataformas seguras.</p>
+                        </div>
+                    </details>
+
+                    <details class="faq">
+                        <summary>¿Cómo reservo y formas de pago?</summary>
+                        <div class="faq-body">
+                            <p>Reserva por WhatsApp o formulario. Pago mediante los métodos indicados tras confirmar la cita.</p>
+                        </div>
+                    </details>
                 </div>
-                <div class="faq-list" style="max-width: 800px; margin: 0 auto;">
-                    <div class="faq-item">
-                        <div class="faq-question"><span>¿Qué necesito para una sesión online?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
-  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
-</svg></div>
-                        <div class="faq-answer"><p>Solo necesitas un ordenador, tablet o móvil con conexión a internet, cámara y micrófono. Usamos Google Meet, que no requiere instalación. Te envío el enlace antes de cada sesión y simplemente clicas para entrar.</p></div>
-                    </div>
-                    <div class="faq-item">
-                        <div class="faq-question"><span>¿Es segura y confidencial la videollamada?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
-  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
-</svg></div>
-                        <div class="faq-answer"><p>Absolutamente. Uso plataformas seguras y cifradas. Además, la confidencialidad está garantizada por el código deontológico del colegio de psicólogos, igual que en terapia presencial.</p></div>
-                    </div>
-                     <div class="faq-item">
-                        <div class="faq-question"><span>¿Cómo se realiza el pago de las sesiones online?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
-  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
-</svg></div>
-                        <div class="faq-answer"><p>El pago se puede realizar cómodamente por Bizum o transferencia bancaria antes de la sesión. Te facilitaré los datos una vez acordemos la cita.</p></div>
-                    </div>
-                     <div class="faq-item">
-                        <div class="faq-question"><span>¿Qué pasa si tengo problemas técnicos durante la sesión?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
-  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
-</svg></div>
-                        <div class="faq-answer"><p>No te preocupes, estas cosas pasan. Si se cae la conexión, simplemente volvemos a conectar. Si el problema persiste, reprogramamos la sesión sin coste adicional.</p></div>
-                    </div>
-                     <div class="faq-item">
-                        <div class="faq-question"><span>¿Puedo combinar sesiones online y presenciales?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
-  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
-</svg></div>
-                        <div class="faq-answer"><p>Por supuesto. Muchos clientes empiezan online y luego vienen presencialmente, o al revés. O combinan según su disponibilidad. Tú decides lo que mejor te venga en cada momento.</p></div>
-                    </div>
-                </div>
+
+                <!-- JSON-LD FAQPage actualizado (máx. 8 Qs) -->
+                <script type="application/ld+json">
+                {
+                  "@context":"https://schema.org",
+                  "@type":"FAQPage",
+                  "mainEntity":[
+                    {"@type":"Question","name":"¿Cuánto dura la terapia?","acceptedAnswer":{"@type":"Answer","text":"Hacemos las sesiones justas y necesarias. Revisamos el progreso alrededor de las 8–10 sesiones como hito de chequeo (no es un tope ni una garantía). Si el cambio llega antes, cerramos antes; si hace falta más, lo acordamos."}},
+                    {"@type":"Question","name":"¿La terapia online es eficaz?","acceptedAnswer":{"@type":"Answer","text":"Para muchos problemas la terapia online es tan eficaz como la presencial. Trabajamos con objetivos claros y tareas entre sesiones."}},
+                    {"@type":"Question","name":"¿Cómo empezamos?","acceptedAnswer":{"@type":"Answer","text":"Primera sesión de evaluación y definición de objetivos. Acordamos señales de progreso y la frecuencia inicial."}},
+                    {"@type":"Question","name":"¿Frecuencia y duración de cada sesión?","acceptedAnswer":{"@type":"Answer","text":"Sesiones de 50–60 minutos. Frecuencia semanal o quincenal según objetivos y evolución."}},
+                    {"@type":"Question","name":"¿Qué problemas trabajo en terapia breve online?","acceptedAnswer":{"@type":"Answer","text":"Ansiedad, estrés, pareja, autoestima, bloqueos y toma de decisiones, entre otros."}},
+                    {"@type":"Question","name":"¿Qué ocurre si no noto avances?","acceptedAnswer":{"@type":"Answer","text":"Revisión a las 8–10 sesiones; ajustamos estrategia u optamos por derivación responsable si es necesario. La prioridad es la eficacia."}},
+                    {"@type":"Question","name":"Confidencialidad y privacidad","acceptedAnswer":{"@type":"Answer","text":"Cumplo normativa sanitaria y código deontológico. Sesiones confidenciales y plataformas seguras."}},
+                    {"@type":"Question","name":"¿Cómo reservo y formas de pago?","acceptedAnswer":{"@type":"Answer","text":"Reserva por WhatsApp o formulario. Pago mediante los métodos indicados tras confirmar la cita."}}
+                  ]
+                }
+                </script>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- aplica clases de fondo alternadas entre tonos arena y porcelana en las secciones de la landing
- centra y airea el titular de comparativa de enfoques y homologa el espaciado general de cabeceras
- reemplaza los bloques de FAQs por una sección única final con contenido y JSON-LD actualizado

## Testing
- not run

## Verificación
- [x] Títulos con más espacio bajo el H2 (coherente con el resto de la web).
- [x] Alternancia de fondos sin repeticiones contiguas (solo #F1F0EC y #F9F9F7).
- [x] “Enfoques: ¿qué cambia realmente?” centrado y con aire.
- [x] Una sola sección de FAQs al final (≤8, sin repeticiones) + JSON-LD válido.
- [ ] Lighthouse (móvil/desktop): CLS≈0, SEO 100.

------
https://chatgpt.com/codex/tasks/task_e_68e8de5567448325a402a575573affa9