### PR TITLE
Adjust online spacing and FAQ layout

### DIFF
--- a/css/terapia-online.css
+++ b/css/terapia-online.css
@@ -43,18 +43,6 @@
 @media (min-width:768px){ #sesiones-justas .compare-grid{ grid-template-columns:1fr 1fr; } }
 #sesiones-justas .note{ font-size:.92rem; opacity:.85; margin-top:.5rem; }
 
-/* ===== FAQs accesibles (solo estilos) ===== */
-#faqs-online .faqs{ display:grid; gap:12px; }
-#faqs-online .faq summary{
-  cursor:pointer; font-weight:600; list-style:none; position:relative; padding:.75rem 2rem .75rem 0;
-}
-#faqs-online .faq summary::-webkit-details-marker{ display:none; }
-#faqs-online .faq summary::after{
-  content:"▾"; position:absolute; right:0; top:.75rem; line-height:1;
-}
-#faqs-online .faq[open] summary::after{ content:"▴"; }
-#faqs-online .faq .faq-body{ padding:.5rem 0 1rem; }
-
 /* ===== Alternancia de fondos (solo esta landing) ===== */
 .bg-sand { background: #F1F0EC; }
 .bg-porcelain { background: #F9F9F7; }
@@ -67,14 +55,77 @@
   margin-top: var(--space-200, .5rem);
 }
 
-/* “Enfoques: ¿qué cambia realmente?” centrado + aire */
-#sesiones-justas .compare > h3 {
-  text-align: center;
-  margin: var(--space-600, 1.25rem) 0 var(--space-500, 1rem);
-}
-
 /* Anti-CLS: cabeceras con altura estable en desktop */
 @media (min-width:1024px){
   #sesiones-justas .section-header { min-height: 110px; }
-  #faqs-online .section-header { min-height: 90px; }
+  #faqs .section-header { min-height: 90px; }
+}
+
+/* ——— Online: tarjetas “Sesiones justas y necesarias” ——— */
+#online-brief .card h3,
+#online-brief .card .card-title {
+  /* más separación con la lista */
+  margin-bottom: 20px; /* antes era menor; subir a ~20px */
+}
+
+#online-brief .card ul {
+  margin-top: 0;      /* por si hay márgenes heredados */
+  padding-left: 1.1em; /* mantener bullets ordenados */
+}
+
+/* ——— Heading “Enfoques” ——— */
+#enfoques-title {
+  text-align: center;
+  margin-top: 56px;   /* más aire por arriba */
+  margin-bottom: 28px;/* y por abajo */
+  line-height: 1.25;  /* legible en dos líneas si se parte */
+}
+
+/* Si el título de “Enfoques” está dentro de .section-title, afinamos solo aquí */
+#enfoques-title.section-title {
+  margin-top: 64px;
+  margin-bottom: 32px;
+}
+
+/* ——— FAQs (estilo estándar del sitio) ——— */
+/* Reutiliza el mismo patrón que en pareja/presencial:
+   contenedor claro, borde izq #6B7A99, esquinas redondeadas.
+   No dupliques reglas: a poder ser usa las clases existentes del componente.
+   Solo añade ajustes si faltan en Online. */
+
+#faqs .faq-item,
+#faqs .accordion-item,
+#faqs .qa-card {
+  background: var(--bg-lighter, #F9F9F7);
+  border-left: 3px solid #6B7A99; /* ribete coherente con el resto de la web */
+  border-radius: 12px;
+  padding: 16px 18px;
+}
+
+/* Espaciado interno coherente con el resto del sitio */
+#faqs .faq-question {
+  margin: 0 0 8px 0;
+}
+
+#faqs .faq-answer {
+  margin: 0;
+}
+
+/* Lista más legible dentro de respuestas */
+#faqs .faq-answer ul {
+  margin: 8px 0 0;
+  padding-left: 1.15em;
+}
+
+/* Asegurar separación entre tarjetas FAQ */
+#faqs .faq-list > * + * {
+  margin-top: 12px;
+}
+
+/* Title de la sección FAQs como en el resto (si no hereda) */
+#faqs .section-title, 
+#faqs h2.section-title {
+  text-align: center;
+  margin-top: 56px;
+  margin-bottom: 20px;
 }

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -189,7 +189,7 @@
         </section>
 
         <section id="sesiones-justas" class="section bg-sand">
-            <div class="container">
+            <div class="container" id="online-brief">
                 <header class="section-header">
                     <h2>Sesiones justas y necesarias</h2>
                     <p class="section-subtitle">
@@ -221,7 +221,7 @@
                 </div>
 
                 <div id="comparativa-breve" class="compare">
-                    <h3>Enfoques: ¿qué cambia realmente?</h3>
+                    <h3 id="enfoques-title">Enfoques: ¿qué cambia realmente?</h3>
                     <div class="compare-grid" role="list">
                         <article class="compare-card" role="listitem" aria-label="Enfoque habitual">
                             <h4>❌ Enfoque habitual</h4>
@@ -475,68 +475,62 @@
         </section>
 
         <!-- 8. FAQ - FONDO CLARO -->
-        <section id="faqs-online" class="section bg-porcelain">
+        <section class="section bg-porcelain" id="faqs">
             <div class="container">
-                <header class="section-header">
-                    <h2>Preguntas frecuentes</h2>
-                </header>
+                <div class="section-header">
+                    <p class="section-subtitle">Resolvemos tus dudas</p>
+                    <h2 class="section-title">Preguntas frecuentes</h2>
+                </div>
 
-                <div class="faqs">
-                    <details class="faq">
-                        <summary>¿Cuánto dura la terapia?</summary>
-                        <div class="faq-body">
-                            <p>Hacemos las <strong>sesiones justas y necesarias</strong>. Revisamos el progreso alrededor de las <strong>8–10 sesiones</strong> como hito de chequeo (no es un tope ni una garantía). Si el cambio llega antes, cerramos antes; si hace falta más, lo acordamos.</p>
-                        </div>
-                    </details>
-
-                    <details class="faq">
-                        <summary>¿La terapia online es eficaz?</summary>
-                        <div class="faq-body">
-                            <p>Sí. Para muchos problemas (ansiedad, pareja, estrés, autoestima) la terapia online es tan eficaz como la presencial, con ventajas de accesibilidad y continuidad. Trabajamos con objetivos claros y tareas entre sesiones.</p>
-                        </div>
-                    </details>
-
-                    <details class="faq">
-                        <summary>¿Cómo empezamos?</summary>
-                        <div class="faq-body">
-                            <p>Primera sesión de evaluación y definición de objetivos observables. Acordamos señales de progreso y la frecuencia inicial (habitualmente semanal).</p>
-                        </div>
-                    </details>
-
-                    <details class="faq">
-                        <summary>¿Frecuencia y duración de cada sesión?</summary>
-                        <div class="faq-body">
-                            <p>Sesiones de <strong>50–60 minutos</strong>. La frecuencia se ajusta (semanal o quincenal) según objetivos y evolución.</p>
-                        </div>
-                    </details>
-
-                    <details class="faq">
-                        <summary>¿Qué problemas trabajo en terapia breve online?</summary>
-                        <div class="faq-body">
-                            <p>Ansiedad, estrés, problemas de pareja, autoestima, bloqueos puntuales y toma de decisiones, entre otros.</p>
-                        </div>
-                    </details>
-
-                    <details class="faq">
-                        <summary>¿Qué ocurre si no noto avances?</summary>
-                        <div class="faq-body">
-                            <p>Revisamos estrategia y objetivos en la revisión (8–10). Si no hay avances suficientes, ajustamos el plan o valoramos derivación responsable. La prioridad es la <strong>eficacia</strong>.</p>
-                        </div>
-                    </details>
-
-                    <details class="faq">
-                        <summary>Confidencialidad y privacidad</summary>
-                        <div class="faq-body">
-                            <p>Cumplo normativa sanitaria y código deontológico. Sesiones confidenciales y plataformas seguras.</p>
-                        </div>
-                    </details>
-
-                    <details class="faq">
-                        <summary>¿Cómo reservo y formas de pago?</summary>
-                        <div class="faq-body">
-                            <p>Reserva por WhatsApp o formulario. Pago mediante los métodos indicados tras confirmar la cita.</p>
-                        </div>
-                    </details>
+                <div class="faq-list" style="max-width: 800px; margin: 0 auto;">
+                    <div class="faq-item">
+                        <div class="faq-question"><span>¿Cuánto dura la terapia?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
+                        <div class="faq-answer"><p>Hacemos las <strong>sesiones justas y necesarias</strong>. Revisamos el progreso alrededor de las <strong>8–10 sesiones</strong> como hito de chequeo (no es un tope ni una garantía). Si el cambio llega antes, cerramos antes; si hace falta más, lo acordamos.</p></div>
+                    </div>
+                    <div class="faq-item">
+                        <div class="faq-question"><span>¿La terapia online es eficaz?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
+                        <div class="faq-answer"><p>Sí. Para muchos problemas (ansiedad, pareja, estrés, autoestima) la terapia online es tan eficaz como la presencial, con ventajas de accesibilidad y continuidad. Trabajamos con objetivos claros y tareas entre sesiones.</p></div>
+                    </div>
+                    <div class="faq-item">
+                        <div class="faq-question"><span>¿Cómo empezamos?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
+                        <div class="faq-answer"><p>Primera sesión de evaluación y definición de objetivos observables. Acordamos señales de progreso y la frecuencia inicial (habitualmente semanal).</p></div>
+                    </div>
+                    <div class="faq-item">
+                        <div class="faq-question"><span>¿Frecuencia y duración de cada sesión?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
+                        <div class="faq-answer"><p>Sesiones de <strong>50–60 minutos</strong>. La frecuencia se ajusta (semanal o quincenal) según objetivos y evolución.</p></div>
+                    </div>
+                    <div class="faq-item">
+                        <div class="faq-question"><span>¿Qué problemas trabajo en terapia breve online?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
+                        <div class="faq-answer"><p>Ansiedad, estrés, problemas de pareja, autoestima, bloqueos puntuales y toma de decisiones, entre otros.</p></div>
+                    </div>
+                    <div class="faq-item">
+                        <div class="faq-question"><span>¿Qué ocurre si no noto avances?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
+                        <div class="faq-answer"><p>Revisamos estrategia y objetivos en la revisión (8–10). Si no hay avances suficientes, ajustamos el plan o valoramos derivación responsable. La prioridad es la <strong>eficacia</strong>.</p></div>
+                    </div>
+                    <div class="faq-item">
+                        <div class="faq-question"><span>Confidencialidad y privacidad</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
+                        <div class="faq-answer"><p>Cumplo normativa sanitaria y código deontológico. Sesiones confidenciales y plataformas seguras.</p></div>
+                    </div>
+                    <div class="faq-item">
+                        <div class="faq-question"><span>¿Cómo reservo y formas de pago?</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 256" class="icon" aria-hidden="true" focusable="false" width="20" height="20" fill="currentColor">
+  <path d="M32 32a24 24 0 0 1 34 0L256 181.5 446 32a24 24 0 1 1 34 34l-192 192a24 24 0 0 1-34 0L32 66a24 24 0 0 1 0-34Z" fill="currentColor" />
+</svg></div>
+                        <div class="faq-answer"><p>Reserva por WhatsApp o formulario. Pago mediante los métodos indicados tras confirmar la cita.</p></div>
+                    </div>
                 </div>
 
                 <!-- JSON-LD FAQPage actualizado (máx. 8 Qs) -->


### PR DESCRIPTION
## Summary
- add dedicated wrapper ids for the “Sesiones justas y necesarias” cards and Enfoques heading to control spacing safely
- center and increase breathing room for the Enfoques heading and apply the standard FAQ card styling used on the rest of the site
- replace the online FAQ markup with the shared accordion component while keeping eight non-duplicated questions and updating JSON-LD

## Testing
- Not run (static content updates)

## Screenshots
### Sesiones justas y necesarias
- Before: ![Sesiones antes](browser:/invocations/kmfddqfv/artifacts/artifacts/online-brief-before.png)
- After: ![Sesiones después](browser:/invocations/ugvmjqvx/artifacts/artifacts/online-brief-after.png)

### Heading “Enfoques”
- Before: ![Heading antes](browser:/invocations/kmfddqfv/artifacts/artifacts/enfoques-title-before.png)
- After: ![Heading después](browser:/invocations/ugvmjqvx/artifacts/artifacts/enfoques-title-after.png)

### FAQs
- Before: ![FAQs antes](browser:/invocations/kmfddqfv/artifacts/artifacts/faqs-before.png)
- After: ![FAQs después](browser:/invocations/ugvmjqvx/artifacts/artifacts/faqs-after.png)

------
https://chatgpt.com/codex/tasks/task_e_68e8ef87139c8325827a51312db8a40c