### PR TITLE
Align terapia online FAQs with shared component

### DIFF
--- a/css/terapia-online.css
+++ b/css/terapia-online.css
@@ -26,22 +26,22 @@
 }
 
 /* ===== Sección Sesiones justas y necesarias + Comparativa ===== */
-#sesiones-justas .sj-grid{ display:grid; gap:24px; grid-template-columns:1fr; }
-@media (min-width:768px){ #sesiones-justas .sj-grid{ grid-template-columns:1fr 1fr; } }
+#online-brief .sj-grid{ display:grid; gap:24px; grid-template-columns:1fr; }
+@media (min-width:768px){ #online-brief .sj-grid{ grid-template-columns:1fr 1fr; } }
 
-#sesiones-justas .sj-card,
-#sesiones-justas .compare-card,
-#sesiones-justas .info-card{
+#online-brief .sj-card,
+#online-brief .compare-card,
+#online-brief .info-card{
   background:#fff; border-left:4px solid #6B7A99;
   border-radius:var(--card-radius,16px);
   box-shadow:var(--card-shadow,0 2px 10px rgba(0,0,0,.06));
   padding:1rem 1.25rem;
 }
 
-#sesiones-justas .compare{ margin-top: 24px; }
-#sesiones-justas .compare-grid{ display:grid; gap:24px; grid-template-columns:1fr; }
-@media (min-width:768px){ #sesiones-justas .compare-grid{ grid-template-columns:1fr 1fr; } }
-#sesiones-justas .note{ font-size:.92rem; opacity:.85; margin-top:.5rem; }
+#online-brief .compare{ margin-top: 24px; }
+#online-brief .compare-grid{ display:grid; gap:24px; grid-template-columns:1fr; }
+@media (min-width:768px){ #online-brief .compare-grid{ grid-template-columns:1fr 1fr; } }
+#online-brief .note{ font-size:.92rem; opacity:.85; margin-top:.5rem; }
 
 /* ===== Alternancia de fondos (solo esta landing) ===== */
 .bg-sand { background: #F1F0EC; }
@@ -57,20 +57,18 @@
 
 /* Anti-CLS: cabeceras con altura estable en desktop */
 @media (min-width:1024px){
-  #sesiones-justas .section-header { min-height: 110px; }
-  #faqs .section-header { min-height: 90px; }
+  #online-brief .section-header { min-height: 110px; }
+  #faq .section-header { min-height: 90px; }
 }
 
 /* ——— Online: tarjetas “Sesiones justas y necesarias” ——— */
-#online-brief .card h3,
-#online-brief .card .card-title {
-  /* más separación con la lista */
-  margin-bottom: 20px; /* antes era menor; subir a ~20px */
+#online-brief .card-title {
+  margin-bottom: 20px;
 }
 
 #online-brief .card ul {
-  margin-top: 0;      /* por si hay márgenes heredados */
-  padding-left: 1.1em; /* mantener bullets ordenados */
+  margin-top: 8px;
+  padding-left: 1.15em;
 }
 
 /* ——— Heading “Enfoques” ——— */
@@ -87,45 +85,3 @@
   margin-bottom: 32px;
 }
 
-/* ——— FAQs (estilo estándar del sitio) ——— */
-/* Reutiliza el mismo patrón que en pareja/presencial:
-   contenedor claro, borde izq #6B7A99, esquinas redondeadas.
-   No dupliques reglas: a poder ser usa las clases existentes del componente.
-   Solo añade ajustes si faltan en Online. */
-
-#faqs .faq-item,
-#faqs .accordion-item,
-#faqs .qa-card {
-  background: var(--bg-lighter, #F9F9F7);
-  border-left: 3px solid #6B7A99; /* ribete coherente con el resto de la web */
-  border-radius: 12px;
-  padding: 16px 18px;
-}
-
-/* Espaciado interno coherente con el resto del sitio */
-#faqs .faq-question {
-  margin: 0 0 8px 0;
-}
-
-#faqs .faq-answer {
-  margin: 0;
-}
-
-/* Lista más legible dentro de respuestas */
-#faqs .faq-answer ul {
-  margin: 8px 0 0;
-  padding-left: 1.15em;
-}
-
-/* Asegurar separación entre tarjetas FAQ */
-#faqs .faq-list > * + * {
-  margin-top: 12px;
-}
-
-/* Title de la sección FAQs como en el resto (si no hereda) */
-#faqs .section-title, 
-#faqs h2.section-title {
-  text-align: center;
-  margin-top: 56px;
-  margin-bottom: 20px;
-}

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -188,8 +188,8 @@
             </div>
         </section>
 
-        <section id="sesiones-justas" class="section bg-sand">
-            <div class="container" id="online-brief">
+        <section id="online-brief" class="section bg-sand">
+            <div class="container">
                 <header class="section-header">
                     <h2>Sesiones justas y necesarias</h2>
                     <p class="section-subtitle">
@@ -199,8 +199,8 @@
                 </header>
 
                 <div class="sj-grid">
-                    <article class="sj-card">
-                        <h3>¿Qué puedes esperar?</h3>
+                    <article class="sj-card card">
+                        <h3 class="card-title">¿Qué puedes esperar?</h3>
                         <ul>
                             <li>Objetivos claros desde la primera sesión.</li>
                             <li>Intervenciones prácticas entre sesiones.</li>
@@ -209,8 +209,8 @@
                         </ul>
                     </article>
 
-                    <article class="sj-card">
-                        <h3>Seguimiento y duración</h3>
+                    <article class="sj-card card">
+                        <h3 class="card-title">Seguimiento y duración</h3>
                         <ul>
                             <li><strong>Revisión</strong> a las 8–10 sesiones como hito de chequeo (no es un tope ni una garantía).</li>
                             <li>Si el cambio llega antes, <strong>cerramos antes</strong>.</li>
@@ -223,8 +223,8 @@
                 <div id="comparativa-breve" class="compare">
                     <h3 id="enfoques-title">Enfoques: ¿qué cambia realmente?</h3>
                     <div class="compare-grid" role="list">
-                        <article class="compare-card" role="listitem" aria-label="Enfoque habitual">
-                            <h4>❌ Enfoque habitual</h4>
+                        <article class="compare-card card" role="listitem" aria-label="Enfoque habitual">
+                            <h4 class="card-title">❌ Enfoque habitual</h4>
                             <ul>
                                 <li>Énfasis en el problema y el pasado.</li>
                                 <li>Duración <em>variable</em>, a medio plazo.</li>
@@ -232,8 +232,8 @@
                             </ul>
                         </article>
 
-                        <article class="compare-card" role="listitem" aria-label="Terapia Sistémica Breve">
-                            <h4>✅ Sistémica Breve</h4>
+                        <article class="compare-card card" role="listitem" aria-label="Terapia Sistémica Breve">
+                            <h4 class="card-title">✅ Sistémica Breve</h4>
                             <ul>
                                 <li>Énfasis en soluciones y recursos presentes.</li>
                                 <li>Proceso <em>acotado</em> cuando es viable (revisión 8–10).</li>
@@ -475,7 +475,7 @@
         </section>
 
         <!-- 8. FAQ - FONDO CLARO -->
-        <section class="section bg-porcelain" id="faqs">
+        <section class="section bg-porcelain" id="faq">
             <div class="container">
                 <div class="section-header">
                     <p class="section-subtitle">Resolvemos tus dudas</p>


### PR DESCRIPTION
## Summary
- Reused the shared FAQ markup on the online therapy landing so it matches pareja/presencial.
- Updated the “Sesiones justas y necesarias” cards to share spacing styles and a consistent anchor id.
- Simplified the online CSS to lean on the shared FAQ styles and added targeted spacing for the brief cards.

## Testing
- Not run (static content update)

## Screenshots
Before | After
:--: | :--:
![Antes](browser:/invocations/ihcuhcxv/artifacts/artifacts/terapia-online-before.png) | ![Después](browser:/invocations/ixgiiwte/artifacts/artifacts/terapia-online-faqs.png)


------
https://chatgpt.com/codex/tasks/task_e_68e8f3843b708325b0f695f387aba0f1