### PR TITLE
Reuse brief block across home and pareja pages

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -198,6 +198,91 @@ section#especializacion .grid-2 > a {
     margin-inline: auto;
 }
 
+/* === Brief model (reusable) === */
+.brief-block .sj-grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+    .brief-block .sj-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+.brief-block .sj-card,
+.brief-block .compare-card,
+.brief-block .info-card {
+    background: #fff;
+    border-left: 4px solid #6B7A99;
+    border-radius: var(--card-radius, 16px);
+    box-shadow: var(--card-shadow, 0 2px 10px rgba(0, 0, 0, 0.06));
+    padding: 1rem 1.25rem;
+}
+
+.brief-block .compare {
+    margin-top: 24px;
+}
+
+.brief-block .compare-grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+    .brief-block .compare-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+.brief-block .note {
+    font-size: 0.92rem;
+    opacity: 0.85;
+    margin-top: 0.5rem;
+}
+
+@media (min-width: 1024px) {
+    .brief-block .section-header {
+        min-height: 110px;
+    }
+}
+
+.brief-block .card-title {
+    margin-bottom: 20px;
+}
+
+.brief-block .card ul {
+    margin-top: 8px;
+    padding-left: 1.15em;
+}
+
+/* Espaciado del h2 central y subtítulo (si existieran en el bloque) */
+.brief-block .section-title {
+    text-align: center;
+    margin-bottom: 24px;
+}
+
+.brief-block .section-subtitle {
+    text-align: center;
+    margin-top: -4px;
+    margin-bottom: 32px;
+}
+
+/* Heading "Enfoques" */
+#enfoques-title {
+    text-align: center;
+    margin-top: 56px;
+    margin-bottom: 28px;
+    line-height: 1.25;
+}
+
+#enfoques-title.section-title {
+    margin-top: 64px;
+    margin-bottom: 32px;
+}
+
 /* ===== Tamaños y offsets estándar ===== */
 :root{
   --icon-cta: 24px;              /* icono en botones */

--- a/css/terapia-online.css
+++ b/css/terapia-online.css
@@ -25,24 +25,6 @@
     }
 }
 
-/* ===== Sección Sesiones justas y necesarias + Comparativa ===== */
-#online-brief .sj-grid{ display:grid; gap:24px; grid-template-columns:1fr; }
-@media (min-width:768px){ #online-brief .sj-grid{ grid-template-columns:1fr 1fr; } }
-
-#online-brief .sj-card,
-#online-brief .compare-card,
-#online-brief .info-card{
-  background:#fff; border-left:4px solid #6B7A99;
-  border-radius:var(--card-radius,16px);
-  box-shadow:var(--card-shadow,0 2px 10px rgba(0,0,0,.06));
-  padding:1rem 1.25rem;
-}
-
-#online-brief .compare{ margin-top: 24px; }
-#online-brief .compare-grid{ display:grid; gap:24px; grid-template-columns:1fr; }
-@media (min-width:768px){ #online-brief .compare-grid{ grid-template-columns:1fr 1fr; } }
-#online-brief .note{ font-size:.92rem; opacity:.85; margin-top:.5rem; }
-
 /* ===== Alternancia de fondos (solo esta landing) ===== */
 .bg-sand { background: #F1F0EC; }
 .bg-porcelain { background: #F9F9F7; }
@@ -57,31 +39,6 @@
 
 /* Anti-CLS: cabeceras con altura estable en desktop */
 @media (min-width:1024px){
-  #online-brief .section-header { min-height: 110px; }
   #faq .section-header { min-height: 90px; }
-}
-
-/* ——— Online: tarjetas “Sesiones justas y necesarias” ——— */
-#online-brief .card-title {
-  margin-bottom: 20px;
-}
-
-#online-brief .card ul {
-  margin-top: 8px;
-  padding-left: 1.15em;
-}
-
-/* ——— Heading “Enfoques” ——— */
-#enfoques-title {
-  text-align: center;
-  margin-top: 56px;   /* más aire por arriba */
-  margin-bottom: 28px;/* y por abajo */
-  line-height: 1.25;  /* legible en dos líneas si se parte */
-}
-
-/* Si el título de “Enfoques” está dentro de .section-title, afinamos solo aquí */
-#enfoques-title.section-title {
-  margin-top: 64px;
-  margin-bottom: 32px;
 }
 

--- a/index.html
+++ b/index.html
@@ -239,8 +239,68 @@
             </div>
         </section>
 
+        <section class="section brief-block" style="background-color: var(--bg-lighter);">
+            <div class="container">
+                <header class="section-header">
+                    <h2>Sesiones justas y necesarias</h2>
+                    <p class="section-subtitle">
+                        Priorizo la <strong>eficacia</strong> por encima de la brevedad: acortamos el proceso cuando es posible,
+                        sin sacrificar resultados.
+                    </p>
+                </header>
+
+                <div class="sj-grid">
+                    <article class="sj-card card">
+                        <h3 class="card-title">¿Qué puedes esperar?</h3>
+                        <ul>
+                            <li>Objetivos claros desde la primera sesión.</li>
+                            <li>Intervenciones prácticas entre sesiones.</li>
+                            <li>Ritmo de trabajo adaptado a tu contexto.</li>
+                            <li>Alta cuando el objetivo se cumple, sin alargar.</li>
+                        </ul>
+                    </article>
+
+                    <article class="sj-card card">
+                        <h3 class="card-title">Seguimiento y duración</h3>
+                        <ul>
+                            <li><strong>Revisión</strong> a las 8–10 sesiones como hito de chequeo (no es un tope ni una garantía).</li>
+                            <li>Si el cambio llega antes, <strong>cerramos antes</strong>.</li>
+                            <li>Si hace falta más, lo <strong>acordamos</strong> juntos.</li>
+                            <li>Sin paquetes cerrados ni promesas de un número fijo.</li>
+                        </ul>
+                    </article>
+                </div>
+
+                <div id="comparativa-breve" class="compare">
+                    <h3 id="enfoques-title">Enfoques: ¿qué cambia realmente?</h3>
+                    <div class="compare-grid" role="list">
+                        <article class="compare-card card" role="listitem" aria-label="Enfoque habitual">
+                            <h4 class="card-title">❌ Enfoque habitual</h4>
+                            <ul>
+                                <li>Énfasis en el problema y el pasado.</li>
+                                <li>Duración <em>variable</em>, a medio plazo.</li>
+                                <li>Objetivos a veces difusos.</li>
+                            </ul>
+                        </article>
+
+                        <article class="compare-card card" role="listitem" aria-label="Terapia Sistémica Breve">
+                            <h4 class="card-title">✅ Sistémica Breve</h4>
+                            <ul>
+                                <li>Énfasis en soluciones y recursos presentes.</li>
+                                <li>Proceso <em>acotado</em> cuando es viable (revisión 8–10).</li>
+                                <li>Objetivos claros y observables desde el inicio.</li>
+                            </ul>
+                        </article>
+                    </div>
+                    <p class="note">
+                        * Rango y tiempos son <strong>orientativos</strong>. La duración real depende de tus objetivos y circunstancias.
+                    </p>
+                </div>
+            </div>
+        </section>
+
         <!-- Section 6: Tarifas -->
-        <section class="section tarifas-section" id="tarifas" style="background-color: var(--bg-lighter);">
+        <section class="section tarifas-section" id="tarifas" style="background-color: var(--bg-main);">
             <div class="container">
                 <div class="section-header">
                     <p class="section-subtitle">Inversión en tu Bienestar</p>

--- a/terapia-online.html
+++ b/terapia-online.html
@@ -188,7 +188,7 @@
             </div>
         </section>
 
-        <section id="online-brief" class="section bg-sand">
+        <section id="online-brief" class="section bg-sand brief-block">
             <div class="container">
                 <header class="section-header">
                     <h2>Sesiones justas y necesarias</h2>

--- a/terapia-pareja.html
+++ b/terapia-pareja.html
@@ -202,6 +202,66 @@
             </div>
         </section>
 
+        <section class="section brief-block" style="background-color: var(--bg-main);">
+            <div class="container">
+                <header class="section-header">
+                    <h2>Sesiones justas y necesarias</h2>
+                    <p class="section-subtitle">
+                        Priorizo la <strong>eficacia</strong> por encima de la brevedad: acortamos el proceso cuando es posible,
+                        sin sacrificar resultados.
+                    </p>
+                </header>
+
+                <div class="sj-grid">
+                    <article class="sj-card card">
+                        <h3 class="card-title">¿Qué puedes esperar?</h3>
+                        <ul>
+                            <li>Objetivos claros desde la primera sesión.</li>
+                            <li>Intervenciones prácticas entre sesiones.</li>
+                            <li>Ritmo de trabajo adaptado a tu contexto.</li>
+                            <li>Alta cuando el objetivo se cumple, sin alargar.</li>
+                        </ul>
+                    </article>
+
+                    <article class="sj-card card">
+                        <h3 class="card-title">Seguimiento y duración</h3>
+                        <ul>
+                            <li><strong>Revisión</strong> a las 8–10 sesiones como hito de chequeo (no es un tope ni una garantía).</li>
+                            <li>Si el cambio llega antes, <strong>cerramos antes</strong>.</li>
+                            <li>Si hace falta más, lo <strong>acordamos</strong> juntos.</li>
+                            <li>Sin paquetes cerrados ni promesas de un número fijo.</li>
+                        </ul>
+                    </article>
+                </div>
+
+                <div id="comparativa-breve" class="compare">
+                    <h3 id="enfoques-title">Enfoques: ¿qué cambia realmente?</h3>
+                    <div class="compare-grid" role="list">
+                        <article class="compare-card card" role="listitem" aria-label="Enfoque habitual">
+                            <h4 class="card-title">❌ Enfoque habitual</h4>
+                            <ul>
+                                <li>Énfasis en el problema y el pasado.</li>
+                                <li>Duración <em>variable</em>, a medio plazo.</li>
+                                <li>Objetivos a veces difusos.</li>
+                            </ul>
+                        </article>
+
+                        <article class="compare-card card" role="listitem" aria-label="Terapia Sistémica Breve">
+                            <h4 class="card-title">✅ Sistémica Breve</h4>
+                            <ul>
+                                <li>Énfasis en soluciones y recursos presentes.</li>
+                                <li>Proceso <em>acotado</em> cuando es viable (revisión 8–10).</li>
+                                <li>Objetivos claros y observables desde el inicio.</li>
+                            </ul>
+                        </article>
+                    </div>
+                    <p class="note">
+                        * Rango y tiempos son <strong>orientativos</strong>. La duración real depende de tus objetivos y circunstancias.
+                    </p>
+                </div>
+            </div>
+        </section>
+
         <!-- Section 5: Testimonios -->
         <section class="section testimonials-section" id="testimonios" role="region" aria-label="Opiniones de clientes">
             <div class="container">


### PR DESCRIPTION
## Summary
- move the "Sesiones justas y necesarias" styles into a reusable `.brief-block` in `common.css`
- apply the shared block to terapia online and embed it on the home and pareja pages with correct background alternation

## Testing
- No automated tests run (static site)

## Screenshots
### Index
**Antes:** ![Index antes](browser:/invocations/npmahuff/artifacts/artifacts/index-brief-block-before.png)
**Después:** ![Index después](browser:/invocations/hugutxtl/artifacts/artifacts/index-brief-block.png)

### Terapia Online
**Antes:** ![Online antes](browser:/invocations/plctzpcg/artifacts/artifacts/online-brief-block-before.png)
**Después:** ![Online después](browser:/invocations/nsyqotfb/artifacts/artifacts/online-brief-block.png)

### Terapia Pareja
**Antes:** ![Pareja antes](browser:/invocations/ghbidedo/artifacts/artifacts/pareja-brief-block-before.png)
**Después:** ![Pareja después](browser:/invocations/digctlse/artifacts/artifacts/pareja-brief-block.png)


------
https://chatgpt.com/codex/tasks/task_e_68e8fbae97388325ba1a17b6d99737bb